### PR TITLE
Fix frontend API base URL and Vercel rewrite

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -25,3 +25,5 @@
   - MidiConverter and StemSplitter already receive `onLoginClick` prop, just need to pass it through
   - The `onLoginClick` prop pattern is well-established across the codebase for login gating
 ---
+
+<!-- retrigger preview 2026-04-19T04:46:28Z -->

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -8,6 +8,7 @@ import { LuGuitar, LuMusic4, LuDrum } from 'react-icons/lu';
 import { Piano } from 'lucide-react';
 import { LiaMicrophoneAltSolid } from 'react-icons/lia';
 import './Hero.css';
+import config from '../config';
 
 const SUPPORTED_MIME_TYPES = [
   'audio/mp3',
@@ -37,9 +38,7 @@ const isSupportedFileType = (selectedFile) => {
   return SUPPORTED_EXTENSIONS.some((ext) => name.endsWith(ext));
 };
 
-// Base URL for the new Orchestrator backend
-// Use /api in both dev and production - Vercel rewrites handle the proxy
-const API_BASE_URL = '/api';
+const API_BASE_URL = config.apiBaseUrl;
 
 // NOTE: Download key maps (stemKeyMap, midiKeyMap) and download handlers are shared across
 // Hero.js, MidiConverter.js, StemSplitter.js, and TranscriptionHistory.js.

--- a/src/components/MidiConverter.js
+++ b/src/components/MidiConverter.js
@@ -13,6 +13,7 @@ import Features from './Features';
 import Pricing from './Pricing';
 import FAQ from './FAQ';
 import './Hero.css';
+import config from '../config';
 
 const SUPPORTED_MIME_TYPES = [
   'audio/mp3',
@@ -38,7 +39,7 @@ const isSupportedFileType = (selectedFile) => {
   return SUPPORTED_EXTENSIONS.some((ext) => name.endsWith(ext));
 };
 
-const API_BASE_URL = '/api';
+const API_BASE_URL = config.apiBaseUrl;
 
 // NOTE: Download key maps (stemKeyMap, midiKeyMap) and download handlers are shared across
 // Hero.js, MidiConverter.js, StemSplitter.js, and TranscriptionHistory.js.
@@ -331,7 +332,7 @@ function MidiConverter({ onLoginClick }) {
             stopped = true;
             return;
           }
-          // Handle cold-start �?processing transition
+          // Handle cold-start â?processing transition
           if (newStatus === 'worker_processing' && (status === 'started' || status === 'pending')) {
             simulateProgress();
             sendNotification('GrooveSheet', { body: 'Server is ready! Converting your audio now.' });

--- a/src/components/StemSplitter.js
+++ b/src/components/StemSplitter.js
@@ -13,6 +13,7 @@ import Features from './Features';
 import Pricing from './Pricing';
 import FAQ from './FAQ';
 import './Hero.css';
+import config from '../config';
 
 const SUPPORTED_MIME_TYPES = [
   'audio/mp3',
@@ -38,7 +39,7 @@ const isSupportedFileType = (selectedFile) => {
   return SUPPORTED_EXTENSIONS.some((ext) => name.endsWith(ext));
 };
 
-const API_BASE_URL = '/api';
+const API_BASE_URL = config.apiBaseUrl;
 
 // NOTE: Download key maps (stemKeyMap) and download handlers are shared across
 // Hero.js, MidiConverter.js, StemSplitter.js, and TranscriptionHistory.js.

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,10 @@ const config = {
   appUrl: process.env.REACT_APP_URL || 'http://localhost:3000',
 
   // API Configuration
-  apiBaseUrl: process.env.REACT_APP_API_BASE_URL || 'https://api.groovesheet.net',
+  apiBaseUrl:
+    process.env.REACT_APP_API_BASE_URL ||
+    process.env.REACT_APP_API_URL ||
+    'https://api.groovesheet.net',
 
   // Feature Flags
   enableAnalytics: process.env.REACT_APP_ENABLE_ANALYTICS === 'true',

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "https://api-orchestrator-test-700212390421.asia-southeast1.run.app/:path*"
+      "destination": "https://api.groovesheet.net/:path*"
     }
   ],
   "headers": [


### PR DESCRIPTION
- replace hardcoded `/api` base URL in frontend components with env-driven config
- support both `REACT_APP_API_BASE_URL` and `REACT_APP_API_URL`
- point Vercel `/api/*` rewrite to `https://api.groovesheet.net/*`

Verified from live site that `www.groovesheet.net/api` is broken while `api.groovesheet.net` is healthy.