### PR TITLE
feat: piano-only launch — hide other instruments, full-screen explore-style result view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -119,20 +119,6 @@ function LandingPage({ onLoginClick }) {
 
   return (
     <div className="app-container">
-      <img
-        src="/overlay.svg"
-        alt=""
-        aria-hidden="true"
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: '60px',
-          width: 'calc(100% - 120px)',
-          height: 'auto',
-          zIndex: 2147483647,
-          pointerEvents: 'none',
-        }}
-      />
       <div className="dot-grid"></div>
       <div
         ref={backgroundRef}

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -30,13 +30,20 @@
   transition: gap 0.3s ease;
 }
 
+/* Success: the hero copy collapses away and the card claims the full width. */
 .hero-container.success-expanded {
   justify-content: center;
   gap: 0;
+  max-width: 100%;
 }
 
 .hero-container.success-expanded .hero-content {
-  display: none;
+  max-width: 0;
+  min-height: 0;
+  padding: 0;
+  opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .hero-content {
@@ -49,6 +56,7 @@
   height: auto;
   padding: 20px 0;
   box-sizing: border-box;
+  transition: max-width 0.45s ease, opacity 0.3s ease, padding 0.45s ease;
 }
 
 .hero-text {
@@ -566,9 +574,20 @@
 
 /* Drag and Drop States */
 .upload-area.state-uploading,
-.upload-area.state-processing,
-.upload-area.state-success {
+.upload-area.state-processing {
   justify-content: center;
+}
+
+/* Success: card expands leftward to fill the screen and hosts the
+   explore-style transcription viewer. */
+.upload-area.state-success {
+  justify-content: flex-start;
+  max-width: 100%;
+  min-height: calc(100vh - 160px);
+}
+
+.upload-area.state-success:hover {
+  transform: none;
 }
 
 .upload-area.dragging {
@@ -953,11 +972,9 @@
   }
 }
 
-/* Full-width success layout — VisualizationPanel takes over */
-.hero-container-success {
-  flex-direction: column;
-  max-width: 100%;
-  gap: 0;
+/* Hide the mobile disclaimer while the expanded result view is on screen */
+.hero-container.success-expanded .hero-disclaimer-mobile {
+  display: none;
 }
 
 /* Success State Specific Styles */

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -3,16 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { useUser, useAuth } from '../auth';
 import confetti from 'canvas-confetti';
 import { authenticatedFetch, downloadWorkflowFile } from '../utils/api';
-import { previewFetch, startPreview, setPendingPreviewId } from '../utils/previewApi';
+import { previewFetch, startPreview, setPendingPreviewId, upgradeToFull } from '../utils/previewApi';
 import { requestNotificationPermission, sendNotification } from '../utils/notifications';
 import { useTheme } from '../context/ThemeContext';
 import { LuGuitar, LuMusic4, LuDrum } from 'react-icons/lu';
 import { Piano } from 'lucide-react';
 import { LiaMicrophoneAltSolid } from 'react-icons/lia';
 import { useWorkflowPersistence } from '../hooks/useWorkflowPersistence';
-import DownloadSection from './visualization/DownloadSection';
-import './visualization/VisualizationPanel.css';
-import PreviewPanel from './PreviewPanel/PreviewPanel';
+import TranscriptionResultView from './TranscriptionResult/TranscriptionResultView';
 import StatusMessage from './ui/StatusMessage';
 import './Hero.css';
 import config from '../config';
@@ -83,19 +81,6 @@ const MagicWandIcon = () => (
   </svg>
 );
 
-const CheckCircleIcon = () => (
-  <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="32" cy="32" r="28" fill="white" stroke="white" strokeWidth="4"/>
-    <path d="M20 32L28 40L44 24" stroke="#171717" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
-
-const CloseIcon = () => (
-  <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M27 9L9 27M9 9L27 27" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
-
 const ServerIcon = () => (
   <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect x="12" y="8" width="40" height="16" rx="3" stroke="white" strokeWidth="3"/>
@@ -120,7 +105,7 @@ const BassIcon = () => (
   </svg>
 );
 
-function Hero({ onLoginRequired: _onLoginRequired }) {
+function Hero({ onLoginRequired }) {
   const { isSignedIn, isLoaded } = useUser();
   const { getToken } = useAuth();
   const { isDarkMode } = useTheme();
@@ -826,15 +811,45 @@ function Hero({ onLoginRequired: _onLoginRequired }) {
     handleDownloadFile(midiKey, '.mid', 'midi');
   };
 
+  // Promote a signed-in user's preview to a full run (no re-upload).
+  const handleUpgradeToFull = async () => {
+    if (!jobId || !jobId.startsWith('PRV')) return;
+    try {
+      const result = await upgradeToFull(API_BASE_URL, jobId, getToken);
+      if (result && result.workflow_id) {
+        // Replace the preview result with the new full workflow's polling.
+        prefetchedFilesRef.current = {};
+        if (downloadUrl) URL.revokeObjectURL(downloadUrl);
+        setDownloadUrl(null);
+        setDownloadFilename(null);
+        setJobId(result.workflow_id);
+        setStatus('processing');
+        setProgress(0);
+        simulateProgress();
+        persist({ jobId: result.workflow_id, status: 'processing', progress: 0, instrument: selectedInstrument, fileName: file?.name });
+        setTimeout(() => pollStatus(result.workflow_id), 1000);
+      }
+    } catch (err) {
+      setError(err.message || 'Failed to start full song processing.');
+    }
+  };
+
+  // preview_id is already stashed in localStorage at upload time; after
+  // signup the app-level hook claims it via /preview/{id}/claim.
+  const handleSignUpToUnlock = () => {
+    if (onLoginRequired) onLoginRequired();
+  };
+
   // Handle browse button click — allow anonymous uploads for preview
   const handleBrowseClick = () => {
     if (!isLoaded) return;
     fileInputRef.current?.click();
   };
 
-  // Drag and drop handlers
+  // Drag and drop handlers — inert while a finished result is on screen.
   const handleDragOver = (e) => {
     e.preventDefault();
+    if (getUIState() === 'success') return;
     setIsDragging(true);
   };
 
@@ -846,6 +861,7 @@ function Hero({ onLoginRequired: _onLoginRequired }) {
   const handleDrop = (e) => {
     e.preventDefault();
     setIsDragging(false);
+    if (getUIState() === 'success') return;
 
     const droppedFile = e.dataTransfer.files[0];
     if (droppedFile) {
@@ -1035,35 +1051,13 @@ function Hero({ onLoginRequired: _onLoginRequired }) {
     </>
   );
 
-  // Success state: render DownloadSection + PreviewPanel (mirror /preview1)
-  if (uiState === 'success') {
-    return (
-      <section className="hero">
-        <div className="hero-container hero-container-success">
-          <div className="viz-panel">
-            <DownloadSection
-              fileName={file?.name}
-              selectedInstrument={selectedInstrument}
-              onDownloadTranscription={handleManualDownload}
-              onDownloadStem={handleDownloadStem}
-              onDownloadMidi={handleDownloadMidi}
-              onReset={resetUpload}
-              downloadError={downloadError}
-            />
-            <PreviewPanel
-              workflowId={jobId}
-              selectedInstrument={selectedInstrument}
-              prefetchedFiles={{}}
-            />
-          </div>
-        </div>
-      </section>
-    );
-  }
+  // On success the upload card expands over the hero copy and fills the
+  // viewport, showing the /explore-style viewer for the fresh transcription.
+  const isSuccess = uiState === 'success';
 
   return (
     <section className="hero">
-      <div className="hero-container">
+      <div className={`hero-container ${isSuccess ? 'success-expanded' : ''}`}>
         <div className="hero-content">
           <div className="hero-text">
             <h1 className="hero-title">{t('hero.title')}</h1>
@@ -1101,6 +1095,22 @@ function Hero({ onLoginRequired: _onLoginRequired }) {
           {uiState === 'uploading' && renderUploadingState()}
           {uiState === 'cold_starting' && renderColdStartState()}
           {uiState === 'processing' && renderProcessingState()}
+          {isSuccess && (
+            <TranscriptionResultView
+              workflowId={jobId}
+              fileName={file?.name || downloadFilename}
+              selectedInstrument={selectedInstrument}
+              prefetchedFiles={prefetchedFilesRef.current}
+              onDownloadTranscription={handleManualDownload}
+              onDownloadStem={handleDownloadStem}
+              onDownloadMidi={handleDownloadMidi}
+              onReset={resetUpload}
+              downloadError={downloadError}
+              isSignedIn={isSignedIn}
+              onUpgradeToFull={handleUpgradeToFull}
+              onSignUpToUnlock={handleSignUpToUnlock}
+            />
+          )}
 
           {/* Error message overlay */}
           {error && (

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -47,6 +47,10 @@ const isSupportedFileType = (selectedFile) => {
 
 const API_BASE_URL = config.apiBaseUrl;
 
+// TODO(launch): only piano is production-ready today. The other instruments are
+// temporarily hidden from the picker — add them back here once their pipelines ship.
+const VISIBLE_INSTRUMENTS = ['piano'];
+
 // NOTE: Download key maps (stemKeyMap, midiKeyMap) and download handlers are shared across
 // Hero.js, MidiConverter.js, StemSplitter.js, and TranscriptionHistory.js.
 // When changing download logic here, update those files too.
@@ -132,7 +136,7 @@ function Hero({ onLoginRequired: _onLoginRequired }) {
   const [isDragging, setIsDragging] = useState(false);
   const [downloadUrl, setDownloadUrl] = useState(null);
   const [downloadFilename, setDownloadFilename] = useState(null);
-  const [selectedInstrument, setSelectedInstrument] = useState('drums');
+  const [selectedInstrument, setSelectedInstrument] = useState('piano');
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
   const fileInputRef = useRef(null);
@@ -156,7 +160,7 @@ function Hero({ onLoginRequired: _onLoginRequired }) {
     setJobId(saved.jobId);
     setStatus(saved.status);
     setProgress(saved.progress || 0);
-    setSelectedInstrument(saved.instrument || 'drums');
+    setSelectedInstrument(saved.instrument || 'piano');
     if (saved.fileName) {
       // Create a minimal file-like object with just the name
       setFile({ name: saved.fileName });
@@ -901,7 +905,7 @@ function Hero({ onLoginRequired: _onLoginRequired }) {
           { value: 'piano', label: t('hero.instruments.piano'), icon: Piano },
           { value: 'guitar', label: t('hero.instruments.guitar'), icon: LuGuitar },
           { value: 'bass', label: t('hero.instruments.bass'), icon: BassIcon }
-        ].map((instrument) => {
+        ].filter((instrument) => VISIBLE_INSTRUMENTS.includes(instrument.value)).map((instrument) => {
           const IconComp = instrument.icon;
           const isSelected = selectedInstrument === instrument.value;
           return (

--- a/src/components/PreviewPanel/PreviewPanel.js
+++ b/src/components/PreviewPanel/PreviewPanel.js
@@ -160,8 +160,14 @@ export default function PreviewPanel({
           buffer = await fetchMidiArrayBuffer(config.apiBaseUrl, workflowId, midiKey, getToken);
         }
         if (cancelled || !buffer) return;
-        const truncated = truncateMidiToSeconds(buffer, 10);
-        setMidiBuffer(truncated || buffer);
+        // Only preview (PRV*) jobs are capped at 10 seconds; full workflows
+        // must show the entire song (the sheet tab already does).
+        if (workflowId.startsWith('PRV')) {
+          const truncated = truncateMidiToSeconds(buffer, 10);
+          setMidiBuffer(truncated || buffer);
+        } else {
+          setMidiBuffer(buffer);
+        }
       } catch (err) {
         if (!cancelled) setMidiError(err.message || 'Failed to load MIDI');
       } finally {

--- a/src/components/TranscriptionResult/TranscriptionResult.css
+++ b/src/components/TranscriptionResult/TranscriptionResult.css
@@ -1,0 +1,162 @@
+/* TranscriptionResultView — explore-style viewer inside the expanded Hero card.
+   Reuses the .gs-song-page scoped styles from song/Song.css for the playbar,
+   viewer toolbar, viewer shell and stems list. Only result-specific chrome
+   lives here. */
+
+.tr-result {
+  width: 100%;
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: left;
+}
+
+/* Header row ---------------------------------------------------------------- */
+.tr-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 10px 6px 0;
+}
+
+.tr-header-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.tr-check {
+  color: #22c55e;
+  flex-shrink: 0;
+}
+
+.tr-header-text {
+  min-width: 0;
+}
+
+.tr-title {
+  margin: 0;
+  font-family: var(--font-family-sans);
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 26px;
+  color: var(--color-text);
+}
+
+.tr-filename {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-family-sans);
+  font-size: 13px;
+  color: var(--color-muted-foreground);
+  min-width: 0;
+}
+
+.tr-filename span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tr-preview-badge {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-light);
+  background: var(--color-surface-light);
+  font-size: 11px;
+  line-height: 16px;
+  color: var(--color-text);
+}
+
+/* Header actions -------------------------------------------------------------- */
+.tr-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tr-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 38px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-light);
+  background: var(--color-surface-light);
+  color: var(--color-text);
+  font-family: var(--font-family-sans);
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.tr-btn:hover {
+  border-color: var(--color-border-lighter);
+  background: var(--color-surface-lighter);
+}
+
+.tr-btn-primary {
+  border: none;
+  background: var(--color-primary);
+  color: var(--color-button-light);
+}
+
+.tr-btn-primary:hover {
+  background: var(--color-primary);
+  filter: brightness(1.15);
+}
+
+.tr-btn-primary:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.tr-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.tr-close:hover {
+  background: var(--color-surface-light);
+}
+
+/* Sticky transport + tabs ------------------------------------------------------ */
+.tr-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+/* The gs-viewer-toolbar spec adds outer margins meant for the song page shell —
+   tighten inside the card. */
+.tr-result .gs-viewer-toolbar {
+  margin: 8px 0;
+}
+
+@media (max-width: 768px) {
+  .tr-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .tr-header-actions {
+    width: 100%;
+  }
+}

--- a/src/components/TranscriptionResult/TranscriptionResultView.js
+++ b/src/components/TranscriptionResult/TranscriptionResultView.js
@@ -1,0 +1,608 @@
+// Full-screen transcription result — shown inside the Hero upload card once a
+// job completes. Mirrors the /explore/:songId viewer stack (PlaybackBar +
+// Sheet / Piano roll / Stems tabs on one shared transport) but is fed from
+// workflow/preview outputs instead of library assets.
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle, DownloadSimple, File, X } from '@phosphor-icons/react';
+import { useAuth } from '../../auth';
+import { useTheme } from '../../context/ThemeContext';
+import config from '../../config';
+import { downloadWorkflowFile, fetchMidiArrayBuffer, fetchMusicXmlText } from '../../utils/api';
+import {
+  MIDI_KEY_BY_INSTRUMENT,
+  MUSICXML_KEY_BY_INSTRUMENT,
+  truncateMidiToSeconds,
+} from '../PreviewPanel/previewUtils';
+import { SheetMusicView, PianoRollView, StemsView } from '../song/SongViewers';
+import PlaybackBar from '../song/PlaybackBar';
+import { Icon } from '../song/icons';
+import StatusMessage from '../ui/StatusMessage';
+import { createTransport } from '../../player/transport';
+import { useTransport } from '../../player/transport-react';
+import { createStemEngine } from '../../player/stemEngine';
+import { createMidiEngine } from '../../player/midiEngine';
+import { createSheetSecMapper } from '../../player/syncMap';
+import '../song/Song.css';
+import './TranscriptionResult.css';
+
+const nowMs = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+// Hero instrument value → BS-Roformer stem download key.
+const STEM_KEY_BY_INSTRUMENT = {
+  drums: 'bs_roformer_drums_stem',
+  piano: 'bs_roformer_piano_stem',
+  bass: 'bs_roformer_bass_stem',
+  jazz_bass: 'bs_roformer_bass_stem',
+  bass_separation: 'bs_roformer_bass_stem',
+  vocals: 'bs_roformer_vocals_stem',
+  guitar: 'bs_roformer_guitar_stem',
+  other: 'bs_roformer_other_stem',
+};
+
+// Hero instrument value → stem_name + display meta (Explore palette).
+const STEM_DISPLAY = {
+  drums: { name: 'drums', label: 'Drums', color: '#FF7BA9', sub: 'kit · percussion' },
+  piano: { name: 'piano', label: 'Piano', color: '#7AA2FF', sub: 'keys · harmonic' },
+  bass: { name: 'bass', label: 'Bass', color: '#FFC857', sub: 'sub · low end' },
+  jazz_bass: { name: 'bass', label: 'Bass', color: '#FFC857', sub: 'sub · low end' },
+  bass_separation: { name: 'bass', label: 'Bass', color: '#FFC857', sub: 'sub · low end' },
+  vocals: { name: 'vocals', label: 'Vocals', color: '#7CC4FF', sub: 'lead · voice' },
+  guitar: { name: 'guitar', label: 'Guitar', color: '#84F2A6', sub: 'strings · plucked' },
+  other: { name: 'other', label: 'Other', color: '#C9A0FF', sub: 'texture · residual' },
+};
+
+function ViewerToolbar({ view, onView, available }) {
+  const tab = (key, IconCmp, label, kbd) => {
+    const enabled = Boolean(available[key]);
+    return (
+      <button
+        className={view === key ? 'on' : ''}
+        onClick={() => enabled && onView(key)}
+        disabled={!enabled}
+        title={enabled ? undefined : 'Not available for this result'}
+        style={enabled ? undefined : { opacity: 0.4, cursor: 'not-allowed' }}
+      >
+        <IconCmp />
+        <span>{label}</span>
+        <span className="gs-seg-kbd">{kbd}</span>
+      </button>
+    );
+  };
+  return (
+    <div className="gs-viewer-toolbar">
+      <div className="gs-seg" role="tablist">
+        {tab('sheet', Icon.Sheet, 'Sheet music', '1')}
+        {tab('midi', Icon.Midi, 'Piano roll', '2')}
+        {tab('stems', Icon.Stems, 'Stem', '3')}
+      </div>
+    </div>
+  );
+}
+
+export default function TranscriptionResultView({
+  workflowId,
+  fileName,
+  selectedInstrument,
+  prefetchedFiles,
+  onDownloadTranscription,
+  onDownloadStem,
+  onDownloadMidi,
+  onReset,
+  downloadError,
+  isSignedIn,
+  onUpgradeToFull,
+  onSignUpToUnlock,
+}) {
+  const { getToken } = useAuth();
+  const { isDarkMode, toggleTheme } = useTheme();
+  const containerRef = useRef(null);
+
+  const isPreview = Boolean(workflowId && workflowId.startsWith('PRV'));
+  const midiKey = MIDI_KEY_BY_INSTRUMENT[selectedInstrument];
+  const musicXmlKey = MUSICXML_KEY_BY_INSTRUMENT[selectedInstrument];
+  const stemKey = STEM_KEY_BY_INSTRUMENT[selectedInstrument];
+  const stemMeta = STEM_DISPLAY[selectedInstrument] || STEM_DISPLAY.other;
+
+  const [upgrading, setUpgrading] = useState(false);
+
+  // --- shared transport ------------------------------------------------------
+  const transportRef = useRef(null);
+  if (!transportRef.current) transportRef.current = createTransport();
+  const transport = transportRef.current;
+  const tState = useTransport(transport);
+  useEffect(() => () => transportRef.current.pause(), []);
+
+  // --- volume (master gain across engines) ------------------------------------
+  const [volume, setVolume] = useState(78);
+  const [muted, setMuted] = useState(false);
+  const masterVolRef = useRef(0.78);
+  const stemEngineRef = useRef(null);
+  const midiEngineRef = useRef(null);
+  useEffect(() => {
+    const v = muted ? 0 : volume / 100;
+    masterVolRef.current = v;
+    if (stemEngineRef.current) stemEngineRef.current.setMasterVolume(v);
+    if (midiEngineRef.current) midiEngineRef.current.setMasterVolume(v);
+  }, [volume, muted]);
+
+  // --- MusicXML ---------------------------------------------------------------
+  const [musicXmlText, setMusicXmlText] = useState(null);
+  const [xmlLoading, setXmlLoading] = useState(true);
+  const [xmlError, setXmlError] = useState(null);
+
+  useEffect(() => {
+    if (!workflowId) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        setXmlLoading(true);
+        setXmlError(null);
+        const prefetched = prefetchedFiles?.[musicXmlKey] || prefetchedFiles?.musicxml;
+        let text = null;
+        if (prefetched?.blob) {
+          text = await prefetched.blob.text();
+        } else {
+          if (musicXmlKey) {
+            text = await fetchMusicXmlText(config.apiBaseUrl, workflowId, getToken, musicXmlKey);
+          }
+          if (!text) {
+            text = await fetchMusicXmlText(config.apiBaseUrl, workflowId, getToken);
+          }
+        }
+        if (!cancelled) setMusicXmlText(text);
+      } catch (err) {
+        if (!cancelled) setXmlError(err.message || 'Failed to load score');
+      } finally {
+        if (!cancelled) setXmlLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [workflowId, musicXmlKey, prefetchedFiles, getToken]);
+
+  // --- MIDI (buffer + soundfont engine) ----------------------------------------
+  const [midiBuffer, setMidiBuffer] = useState(null);
+  const [midiLoading, setMidiLoading] = useState(Boolean(midiKey));
+  const [midiError, setMidiError] = useState(null);
+
+  useEffect(() => {
+    if (!workflowId || !midiKey) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        setMidiLoading(true);
+        setMidiError(null);
+        const prefetched = prefetchedFiles?.[midiKey];
+        let buffer;
+        if (prefetched?.blob) {
+          buffer = await prefetched.blob.arrayBuffer();
+        } else {
+          buffer = await fetchMidiArrayBuffer(config.apiBaseUrl, workflowId, midiKey, getToken);
+        }
+        if (cancelled || !buffer) return;
+        // Preview outputs are already 10s server-side; the client cap is a
+        // safety net for previews only — full workflows show the whole song.
+        setMidiBuffer(isPreview ? truncateMidiToSeconds(buffer, 10) || buffer : buffer);
+      } catch (err) {
+        if (!cancelled) setMidiError(err.message || 'Failed to load MIDI');
+      } finally {
+        if (!cancelled) setMidiLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [workflowId, midiKey, prefetchedFiles, getToken, isPreview]);
+
+  useEffect(() => {
+    if (!midiBuffer) return undefined;
+    const t = transportRef.current;
+    const engine = createMidiEngine({
+      midiBuffer,
+      onError: (err) => setMidiError(err.message || 'Failed to parse MIDI'),
+    });
+    engine.setMasterVolume(masterVolRef.current);
+    midiEngineRef.current = engine;
+    t.attachEngine(engine);
+    // MIDI duration is the transport's source of truth for this result.
+    const dur = engine.getDuration();
+    if (dur > 0) t.setDuration(dur);
+    if (t.getActiveEngineId() === 'midi') {
+      const st = t.getState();
+      if (st.isPlaying) engine.play(st.positionSec);
+      else engine.seek(st.positionSec);
+    }
+    return () => {
+      t.detachEngine('midi');
+      engine.dispose();
+      if (midiEngineRef.current === engine) midiEngineRef.current = null;
+    };
+  }, [midiBuffer]);
+
+  // --- Stem audio (single separated stem → Web Audio engine) --------------------
+  const [stemStatus, setStemStatus] = useState(stemKey ? 'loading' : 'missing');
+  const [stemError, setStemError] = useState(null);
+
+  useEffect(() => {
+    if (!workflowId || !stemKey) return undefined;
+    let cancelled = false;
+    let engine = null;
+    let objectUrl = null;
+    const t = transportRef.current;
+    setStemStatus('loading');
+    setStemError(null);
+    (async () => {
+      try {
+        const prefetched = prefetchedFiles?.[stemKey];
+        const result = prefetched?.blob
+          ? prefetched
+          : await downloadWorkflowFile(config.apiBaseUrl, workflowId, stemKey, getToken);
+        if (cancelled) return;
+        if (!result?.blob) {
+          setStemStatus('missing');
+          return;
+        }
+        objectUrl = URL.createObjectURL(result.blob);
+        engine = createStemEngine({
+          assets: [
+            { asset_type: 'stem', stem_name: stemMeta.name, format: 'wav', stream_url: objectUrl },
+          ],
+          onError: (err) => {
+            setStemError(err.message || 'Failed to load stem audio');
+            setStemStatus('error');
+          },
+        });
+        engine.setMasterVolume(masterVolRef.current);
+        stemEngineRef.current = engine;
+        t.attachEngine(engine);
+        setStemStatus('ready');
+      } catch (err) {
+        if (!cancelled) {
+          setStemError(err.message || 'Failed to load stem audio');
+          setStemStatus('error');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      t.detachEngine('stems');
+      if (engine) engine.dispose();
+      if (stemEngineRef.current === engine) stemEngineRef.current = null;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workflowId, stemKey]);
+
+  const stems = useMemo(
+    () => [{ name: stemMeta.name, label: stemMeta.label, color: stemMeta.color, sub: stemMeta.sub, wave: null }],
+    [stemMeta]
+  );
+  const [stemState, setStemState] = useState({});
+  useEffect(() => {
+    setStemState({ [stemMeta.name]: { mute: false, solo: false, volume: 75 } });
+  }, [stemMeta.name]);
+  useEffect(() => {
+    const eng = stemEngineRef.current;
+    if (!eng) return;
+    Object.entries(stemState).forEach(([name, s]) => {
+      if (!s) return;
+      eng.setStemGain(name, s.volume / 100);
+      eng.setStemMuted(name, s.mute);
+    });
+  }, [stemState, stemStatus]);
+  const onStemChange = useCallback(
+    (name, patch) => setStemState((s) => ({ ...s, [name]: { ...(s[name] || {}), ...patch } })),
+    []
+  );
+
+  // --- OSMD (sheet) engine — same wiring as SongDetail/PreviewPanel -------------
+  const osmdRef = useRef(null);
+  const osmdSyncRef = useRef({ time: 0, playing: false, duration: 0, ready: false });
+  const osmdBaseRef = useRef(0);
+  const mapperRef = useRef(createSheetSecMapper({}));
+  const sheetDurRef = useRef(0);
+  const pendingOsmdSyncRef = useRef(false);
+  const osmdExpectRef = useRef(null); // { sheetSec, until } | null
+
+  const rebuildMapper = useCallback(() => {
+    mapperRef.current = createSheetSecMapper({ sheetDurationSec: sheetDurRef.current });
+  }, []);
+
+  // OSMD's playFromMs awaits pause() internally; serialize seek/play commands.
+  const osmdCmdQueueRef = useRef(Promise.resolve());
+  const commandOsmd = useCallback((sheetSec, andPlay) => {
+    if (!osmdRef.current) return;
+    osmdExpectRef.current = { sheetSec, until: nowMs() + 4000 };
+    osmdCmdQueueRef.current = osmdCmdQueueRef.current
+      .then(async () => {
+        const osmd = osmdRef.current;
+        if (!osmd) return;
+        try { await osmd.seekMs?.(sheetSec * 1000); } catch (e) { /* ignore */ }
+        osmdBaseRef.current = sheetSec;
+        const t = transportRef.current;
+        if (andPlay && t.getState().isPlaying && t.getActiveEngineId() === 'osmd') {
+          try { await osmd.play?.(); } catch (e) { /* ignore */ }
+        }
+        const expect = osmdExpectRef.current;
+        if (expect && expect.sheetSec === sheetSec) {
+          osmdExpectRef.current = { sheetSec, until: nowMs() + 1500 };
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const hasSheet = Boolean(musicXmlText);
+
+  useEffect(() => {
+    if (!hasSheet) return undefined;
+    const t = transportRef.current;
+    t.attachEngine({
+      id: 'osmd',
+      play: (atSec) => {
+        if (!osmdRef.current || !osmdSyncRef.current.ready) {
+          pendingOsmdSyncRef.current = true;
+          return;
+        }
+        commandOsmd(mapperRef.current.midiSecToSheetSec(atSec), true);
+      },
+      pause: () => {
+        try { osmdRef.current?.pause?.(); } catch (e) { /* ignore */ }
+      },
+      seek: (sec) => {
+        if (!osmdRef.current || !osmdSyncRef.current.ready) {
+          pendingOsmdSyncRef.current = true;
+          return;
+        }
+        commandOsmd(mapperRef.current.midiSecToSheetSec(sec), false);
+      },
+      readTime: () => {
+        const s = osmdSyncRef.current;
+        if (!s.ready) return null;
+        const eff = osmdBaseRef.current + s.time;
+        const expect = osmdExpectRef.current;
+        if (expect) {
+          const settled = Math.abs(eff - expect.sheetSec) <= 0.75;
+          if (!settled && nowMs() < expect.until) return null; // stale — self-advance
+          if (!settled) return null;
+          osmdExpectRef.current = null;
+        }
+        return mapperRef.current.sheetSecToMidiSec(eff);
+      },
+    });
+    return () => {
+      t.detachEngine('osmd');
+    };
+  }, [hasSheet, commandOsmd]);
+
+  const handleOsmdStateChange = useCallback(
+    (s) => {
+      const t = transportRef.current;
+      osmdSyncRef.current = { time: s.currentTime, playing: s.isPlaying, duration: s.duration, ready: true };
+      if (s.duration > 0 && sheetDurRef.current !== s.duration) {
+        sheetDurRef.current = s.duration;
+        rebuildMapper();
+        // No MIDI duration yet? Use the sheet's so the scrubber works.
+        if (!(transportRef.current.getState().durationSec > 0)) {
+          t.setDuration(mapperRef.current.sheetSecToMidiSec(s.duration));
+        }
+      }
+      if (pendingOsmdSyncRef.current && osmdRef.current && t.getActiveEngineId() === 'osmd') {
+        pendingOsmdSyncRef.current = false;
+        const st = t.getState();
+        commandOsmd(mapperRef.current.midiSecToSheetSec(st.positionSec), st.isPlaying);
+      }
+      // Reconcile: OSMD pauses itself at the end of the sheet.
+      if (t.getActiveEngineId() === 'osmd') {
+        const st = t.getState();
+        if (
+          st.isPlaying && !s.isPlaying && s.duration > 0 &&
+          osmdBaseRef.current + s.currentTime >= s.duration - 0.05 && st.positionSec > 0.5
+        ) {
+          t.pause();
+        }
+      }
+    },
+    [rebuildMapper, commandOsmd]
+  );
+
+  // Cursor-follow while another engine drives the clock.
+  useEffect(() => {
+    if (!hasSheet) return undefined;
+    const t = transportRef.current;
+    return t.subscribe((st) => {
+      if (t.getActiveEngineId() === 'osmd') return;
+      const osmd = osmdRef.current;
+      if (!osmd) return;
+      try { osmd.syncCursorToTime?.(mapperRef.current.midiSecToSheetSec(st.positionSec)); } catch (e) { /* ignore */ }
+    });
+  }, [hasSheet]);
+
+  // --- tabs ----------------------------------------------------------------------
+  const available = useMemo(
+    () => ({
+      sheet: xmlLoading || Boolean(musicXmlText),
+      midi: midiLoading || Boolean(midiBuffer),
+      stems: stemStatus === 'loading' || stemStatus === 'ready',
+    }),
+    [xmlLoading, musicXmlText, midiLoading, midiBuffer, stemStatus]
+  );
+  const [view, setView] = useState('sheet');
+  useEffect(() => {
+    if (!available[view]) {
+      const first = ['sheet', 'midi', 'stems'].find((v) => available[v]);
+      if (first) setView(first);
+    }
+  }, [available, view]);
+
+  // Active engine follows the visible tab.
+  useEffect(() => {
+    const t = transportRef.current;
+    if (view === 'sheet') {
+      osmdSyncRef.current = { ...osmdSyncRef.current, ready: false };
+      osmdBaseRef.current = 0; // fresh OSMD instance starts at 0
+      pendingOsmdSyncRef.current = true;
+      t.setActiveEngine('osmd');
+    } else if (view === 'midi') {
+      t.setActiveEngine('midi');
+    } else if (view === 'stems') {
+      t.setActiveEngine('stems');
+    }
+  }, [view]);
+
+  // --- playback handlers -----------------------------------------------------------
+  const handlePlayPause = useCallback(() => {
+    const t = transportRef.current;
+    const st = t.getState();
+    if (st.isPlaying) t.pause();
+    else {
+      if (st.durationSec > 0 && st.positionSec >= st.durationSec) t.seek(0);
+      t.play();
+    }
+  }, []);
+
+  const onSeekFraction = useCallback((f) => {
+    const t = transportRef.current;
+    const dur = t.getState().durationSec;
+    if (dur > 0) t.seek(Math.max(0, Math.min(1, f)) * dur);
+  }, []);
+
+  // Keyboard shortcuts (space = play/pause, 1/2/3 = tabs).
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.target && /(input|textarea|select)/i.test(e.target.tagName)) return;
+      if (e.code === 'Space') {
+        e.preventDefault();
+        handlePlayPause();
+      }
+      if (e.key === '1' && available.sheet) setView('sheet');
+      if (e.key === '2' && available.midi) setView('midi');
+      if (e.key === '3' && available.stems) setView('stems');
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [handlePlayPause, available]);
+
+  const handleUpgradeClick = useCallback(async () => {
+    if (!onUpgradeToFull || upgrading) return;
+    setUpgrading(true);
+    try {
+      await onUpgradeToFull();
+    } finally {
+      setUpgrading(false);
+    }
+  }, [onUpgradeToFull, upgrading]);
+
+  return (
+    <div ref={containerRef} className="gs-song-page tr-result">
+      {/* Header: status + downloads + preview CTA */}
+      <div className="tr-header">
+        <div className="tr-header-info">
+          <CheckCircle size={32} weight="fill" className="tr-check" />
+          <div className="tr-header-text">
+            <h2 className="tr-title">Transcription complete</h2>
+            <div className="tr-filename">
+              <File size={16} />
+              <span>{fileName || 'Unknown file'}</span>
+              {isPreview && <span className="tr-preview-badge">10-second preview</span>}
+            </div>
+          </div>
+        </div>
+        <div className="tr-header-actions">
+          {isPreview && (
+            isSignedIn ? (
+              <button className="tr-btn tr-btn-primary" onClick={handleUpgradeClick} disabled={upgrading}>
+                {upgrading ? 'Starting…' : 'Transcribe the full song'}
+              </button>
+            ) : (
+              <button className="tr-btn tr-btn-primary" onClick={onSignUpToUnlock}>
+                Sign up to unlock the full song
+              </button>
+            )
+          )}
+          <button className="tr-btn" onClick={onDownloadTranscription}>
+            <DownloadSimple size={18} weight="bold" />
+            <span>Score</span>
+          </button>
+          {midiKey && (
+            <button className="tr-btn" onClick={onDownloadMidi}>
+              <DownloadSimple size={18} weight="bold" />
+              <span>MIDI</span>
+            </button>
+          )}
+          {stemKey && (
+            <button className="tr-btn" onClick={onDownloadStem}>
+              <DownloadSimple size={18} weight="bold" />
+              <span>Stem</span>
+            </button>
+          )}
+          <button className="tr-close" onClick={onReset} aria-label="Close and start over">
+            <X size={22} weight="bold" />
+          </button>
+        </div>
+      </div>
+
+      {downloadError && <StatusMessage variant="error">{downloadError}</StatusMessage>}
+
+      {/* Sticky transport + tab switcher, same stack as /explore/:songId */}
+      <div className="tr-sticky">
+        <PlaybackBar
+          isPlaying={tState.isPlaying}
+          onPlayPause={handlePlayPause}
+          currentSec={tState.positionSec}
+          totalSec={tState.durationSec}
+          tempo={100}
+          onTempo={() => {}}
+          transpose={0}
+          onTranspose={() => {}}
+          loopMode="off"
+          onLoopMode={() => {}}
+          loopRegion={null}
+          volume={volume}
+          onVolume={setVolume}
+          muted={muted}
+          onMute={() => setMuted((m) => !m)}
+          metronome={false}
+          onMetronome={() => {}}
+          dark={isDarkMode}
+          onToggleTheme={toggleTheme}
+          onFullscreen={() => {
+            if (document.fullscreenElement) document.exitFullscreen();
+            else containerRef.current?.requestFullscreen?.();
+          }}
+          onSeekFraction={onSeekFraction}
+          totalBeats={0}
+          disabledControls={{ tempo: true, transpose: true, metronome: true, loop: true }}
+        />
+        <ViewerToolbar view={view} onView={setView} available={available} />
+      </div>
+
+      {/* Viewer */}
+      <div className="gs-viewer">
+        {view === 'sheet' && (
+          <SheetMusicView
+            musicXmlText={musicXmlText}
+            loading={xmlLoading}
+            error={xmlError}
+            osmdRef={osmdRef}
+            onPlaybackStateChange={handleOsmdStateChange}
+          />
+        )}
+        {view === 'midi' && (
+          <PianoRollView
+            midiBuffer={midiBuffer}
+            transport={transport}
+            loading={midiLoading}
+            error={midiError}
+          />
+        )}
+        {view === 'stems' && (
+          <StemsView
+            stems={stems}
+            stemState={stemState}
+            onStemChange={onStemChange}
+            onSeek={onSeekFraction}
+            transport={transport}
+            statusText={stemError || (stemStatus === 'loading' ? 'Loading stem…' : null)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TranscriptionResult/TranscriptionResultView.js
+++ b/src/components/TranscriptionResult/TranscriptionResultView.js
@@ -12,6 +12,7 @@ import {
   MIDI_KEY_BY_INSTRUMENT,
   MUSICXML_KEY_BY_INSTRUMENT,
   truncateMidiToSeconds,
+  truncateMusicXmlToMeasures,
 } from '../PreviewPanel/previewUtils';
 import { SheetMusicView, PianoRollView, StemsView } from '../song/SongViewers';
 import PlaybackBar from '../song/PlaybackBar';
@@ -149,6 +150,9 @@ export default function TranscriptionResultView({
             text = await fetchMusicXmlText(config.apiBaseUrl, workflowId, getToken);
           }
         }
+        // Previews show a teaser: cap the engraved score alongside the
+        // 10-second MIDI cap so every tab tells the same story.
+        if (text && isPreview) text = truncateMusicXmlToMeasures(text);
         if (!cancelled) setMusicXmlText(text);
       } catch (err) {
         if (!cancelled) setXmlError(err.message || 'Failed to load score');
@@ -157,7 +161,7 @@ export default function TranscriptionResultView({
       }
     })();
     return () => { cancelled = true; };
-  }, [workflowId, musicXmlKey, prefetchedFiles, getToken]);
+  }, [workflowId, musicXmlKey, prefetchedFiles, getToken, isPreview]);
 
   // --- MIDI (buffer + soundfont engine) ----------------------------------------
   const [midiBuffer, setMidiBuffer] = useState(null);

--- a/src/components/song/SongViewers.js
+++ b/src/components/song/SongViewers.js
@@ -295,7 +295,15 @@ export function PianoRollView({ midiBuffer, transport, loading, error }) {
 // variable (--gs-prog, a percentage) on the list element, and each row's
 // bright-waveform clip + playhead line are pure CSS off that variable — no
 // React re-render per frame.
-export function StemsView({ stems, stemState, onStemChange, onSeek, transport, statusText }) {
+export function StemsView({
+  stems,
+  stemState,
+  onStemChange,
+  onSeek,
+  transport,
+  statusText,
+  separatorName = 'GrooveSheet BS-Roformer',
+}) {
   const listRef = useRef(null);
 
   useEffect(() => {
@@ -344,7 +352,7 @@ export function StemsView({ stems, stemState, onStemChange, onSeek, transport, s
       >
         <span>
           Sources: {stems.length} stems · separated by{' '}
-          <strong style={{ color: 'var(--color-text)' }}>GrooveSheet Demucs-v4</strong>.
+          <strong style={{ color: 'var(--color-text)' }}>{separatorName}</strong>.
         </span>
         {statusText && <span>{statusText}</span>}
       </div>

--- a/src/components/song/SongViewers.js
+++ b/src/components/song/SongViewers.js
@@ -14,6 +14,13 @@ import StatusMessage from '../ui/StatusMessage';
 // 1) Sheet Music — OSMD
 // =================================================================
 export function SheetMusicView({ musicXmlText, loading, error, osmdRef, onPlaybackStateChange }) {
+  // A score with no sounding notes (e.g. piano transcription of a track that
+  // has no piano) makes OSMD's cursor init throw inside render() — never
+  // mount the viewer for one, show an explanatory empty state instead.
+  const hasNotes = useMemo(
+    () => !musicXmlText || /<pitch[\s>]|<unpitched[\s>]/.test(musicXmlText),
+    [musicXmlText]
+  );
   return (
     <div
       className="gs-sheet-scroll"
@@ -34,7 +41,15 @@ export function SheetMusicView({ musicXmlText, loading, error, osmdRef, onPlayba
           {error}
         </div>
       )}
-      {!loading && !error && musicXmlText && (
+      {!loading && !error && musicXmlText && !hasNotes && (
+        <div style={{ maxWidth: 560, margin: '48px auto 0' }}>
+          <StatusMessage variant="info" title="No notes detected">
+            We couldn&apos;t find any piano in this section of the audio. Try a
+            recording where the piano is clearly audible.
+          </StatusMessage>
+        </div>
+      )}
+      {!loading && !error && musicXmlText && hasNotes && (
         <div className="gs-sheet-page" style={{ maxWidth: 860, margin: '0 auto' }}>
           <OSMDViewer
             ref={osmdRef}


### PR DESCRIPTION
## Summary
- Temporarily hide all instruments except **Piano** in the Hero upload picker (`VISIBLE_INSTRUMENTS` list in Hero.js — one-line change to re-enable later); piano is the default everywhere.
- On transcription completion the upload card now **expands over the hero copy to fill the viewport** and renders the same viewer stack as `/explore/:songId` (PlaybackBar + Sheet / Piano roll / Stem tabs on one shared transport), fed from the workflow outputs. New `TranscriptionResult/TranscriptionResultView.js`.
- Add the preview CTA to the home page: signed-out → "Sign up to unlock the full song", signed-in → "Transcribe the full song" via the existing `upgradeToFull` endpoint.
- 10-second preview fixes: MIDI truncation no longer applies to full workflows (full songs showed a 10s piano roll), and preview sheet music is now capped via the previously-unused `truncateMusicXmlToMeasures` so all preview tabs agree.

## Test plan
- Verified in a live dev browser: piano-only idle state, upload → transcribing animation → card expansion, all three viewer tabs render (engraved OSMD score with cursor, canvas piano roll, stem mixer), 10s duration cap on previews, sign-up CTA for anonymous users.
- `npm run build` passes; eslint clean on touched files.
- ⚠️ Depends on groovesheet-be `fix/preview-anon-cookie` being deployed for the anonymous preview flow to work in production (gs_anon Set-Cookie is currently dropped — anonymous status polling 403s today).
- Playback audio should be spot-checked by ear in a real browser (headless test env never fires rAF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)