### PR TITLE
fix(song): readable API errors + real 404 page for missing tracks

### DIFF
--- a/public/design/not-found.html
+++ b/public/design/not-found.html
@@ -148,6 +148,22 @@
 </div>
 <script>
   (function () {
+    // Optional ?title= / ?body= overrides so app routes (e.g. a missing
+    // library track) can reuse this page with their own copy. textContent
+    // only — query params must never become markup.
+    var params = new URLSearchParams(window.location.search);
+    var titleParam = params.get('title');
+    var bodyParam = params.get('body');
+    if (titleParam) {
+      var h1 = document.querySelector('main h1');
+      if (h1) h1.textContent = titleParam;
+      document.title = titleParam + ' · GrooveSheet';
+    }
+    if (bodyParam) {
+      var copy = document.querySelector('main h1 + p');
+      if (copy) copy.textContent = bodyParam;
+    }
+
     var disc = document.querySelector('.gs404-disc');
     var number = document.querySelector('.gs404-number');
     if (disc && number) {

--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -10,12 +10,20 @@ import React from 'react';
  * on every element, which would otherwise override the design).
  *
  * Links inside the design use target="_top" so they navigate the parent window.
+ *
+ * `title`/`body` override the page's headline and copy (passed as query
+ * params; the design reads them with textContent, so plain text only) —
+ * lets routes like /explore/:songId reuse this page for "Track not found".
  */
-function NotFound() {
+function NotFound({ title, body }) {
+  const params = new URLSearchParams();
+  if (title) params.set('title', title);
+  if (body) params.set('body', body);
+  const query = params.toString();
   return (
     <iframe
       title="Page not found"
-      src={`${process.env.PUBLIC_URL}/design/not-found.html`}
+      src={`${process.env.PUBLIC_URL}/design/not-found.html${query ? `?${query}` : ''}`}
       style={{
         position: 'fixed',
         inset: 0,

--- a/src/components/song/SongDetail.js
+++ b/src/components/song/SongDetail.js
@@ -7,6 +7,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom';
 import Header from '../layout/Header';
 import Footer from '../layout/Footer';
+import NotFound from '../NotFound';
 import { useTheme } from '../../context/ThemeContext';
 import { useLocalizedNavigate } from '../../i18n/locale';
 import { Icon } from './icons';
@@ -766,7 +767,13 @@ function SongDetail({ onLoginClick }) {
       </span>
     ) : null;
 
-  const notFound = trackError && (trackError.status === 404 || trackError.status === 422);
+  // Only a real 404 means "track gone" — anything else (422, 5xx) is a bug or
+  // outage and must surface as a load error, not masquerade as a missing track.
+  const notFound = trackError && trackError.status === 404;
+
+  if (notFound) {
+    return <NotFound title="Track not found" body="It may have been removed from the library. Let's get you back to the downbeat." />;
+  }
 
   return (
     <div className="gs-song-page">
@@ -782,8 +789,8 @@ function SongDetail({ onLoginClick }) {
 
         {trackError && (
           <CenteredNotice
-            title={notFound ? 'Track not found' : 'Could not load this track'}
-            body={notFound ? 'It may have been removed from the library.' : trackError.message}
+            title="Could not load this track"
+            body={trackError.message}
             actionLabel="Back to explore"
             onAction={() => navigate('/explore')}
           />

--- a/src/utils/libraryApi.js
+++ b/src/utils/libraryApi.js
@@ -30,7 +30,16 @@ async function parseErrorDetail(response) {
   let detail = response.statusText || `Request failed (${response.status})`;
   try {
     const data = await response.clone().json();
-    detail = data.detail || data.message || detail;
+    const raw = data.detail || data.message;
+    if (typeof raw === 'string') {
+      detail = raw;
+    } else if (Array.isArray(raw)) {
+      // FastAPI validation errors: [{loc, msg, type}, ...] — surface the
+      // messages, not "[object Object]".
+      detail = raw.map((e) => (e && e.msg) || JSON.stringify(e)).join('; ') || detail;
+    } else if (raw) {
+      detail = JSON.stringify(raw);
+    }
   } catch (_) {
     // Non-JSON error body — keep the status text.
   }


### PR DESCRIPTION
Recovers prior-session uncommitted fixes: FastAPI validation arrays rendered as "[object Object]" in error banners, and 422/5xx masquerading as "track not found". Only true 404s show the branded NotFound page (with contextual copy via query params).

🤖 Generated with [Claude Code](https://claude.com/claude-code)