### PR TITLE
feat(analytics): add Google Tag Manager container GTM-P9XDD5Z7

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-P9XDD5Z7');</script>
+    <!-- End Google Tag Manager -->
+
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LJ5P8PF3YH"></script>
     <script>
@@ -54,6 +62,11 @@
     <title>GrooveSheet</title>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P9XDD5Z7"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>


### PR DESCRIPTION
Installs Google Tag Manager (container `GTM-P9XDD5Z7`) in `public/index.html`.

- Head `<script>` placed as high as possible in `<head>`
- `<noscript>` iframe immediately after `<body>` opens
- Runs alongside the existing GA4 `gtag.js` (`G-LJ5P8PF3YH`); no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)