### PR TITLE
404 site chrome + DrumScore→GrooveSheet rebrand

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 REACT_APP_API_URL=http://localhost:8080
 
 # Application Configuration
-REACT_APP_NAME=DrumScore
+REACT_APP_NAME=GrooveSheet
 REACT_APP_URL=http://localhost:3000
 
 # Feature Flags

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DrumScore Frontend
+# GrooveSheet Frontend
 
 High-quality drum notation generation with AI-powered technology.
 

--- a/design-system/VISUAL_GUIDE.md
+++ b/design-system/VISUAL_GUIDE.md
@@ -4,7 +4,7 @@ GrooveSheet is an AI-powered music transcription web app. You upload an audio fi
 
 The brand reads as **studio-grade tooling for working musicians** — confident, technical, and a little playful. Brand color is a single, saturated cobalt blue (`#012FA7`) sitting on a near-black canvas, with one signature flourish: a soft blue dot-grid pattern that runs through every dark surface like sheet music staff lines.
 
-> Internally the codebase still references its previous name "DrumScore" in some files (e.g. the footer copyright). The user-facing brand is **GrooveSheet** everywhere new is built.
+> The user-facing brand is **GrooveSheet** everywhere. (The only remaining internal references to the old "DrumScore" name are backend API workflow tokens like `separate_to_drumscore_full`, which are part of the API contract and must not be renamed.)
 
 ---
 
@@ -237,5 +237,5 @@ ui_kits/
 ## ⚠️ Caveats
 
 - **Hubot Sans:** the official variable font ships locally from `assets/fonts/HubotSans-VariableFont_wdth_wght.ttf` (and italic). `colors_and_type.css` declares `@font-face` rules with weight 200–900 and width 75–125%, so all weights and widths are available — including italic.
-- **The codebase still says "DrumScore"** in `README.md` and the footer copyright. We've used **GrooveSheet** everywhere in this design system per the brand assets. Flag if a different convention is wanted.
+- **Brand name is GrooveSheet** everywhere user-facing (README, footer copyright, logo alt text, i18n strings). The only leftover "DrumScore" strings are backend API workflow tokens (e.g. `separate_to_drumscore_full`) — API contract, do not rename.
 - **Hand-rolled feature illustrations** are kept inline in source. If you need them as standalone SVGs in `assets/`, ask and we'll extract.

--- a/design-system/components/Footer.md
+++ b/design-system/components/Footer.md
@@ -23,7 +23,7 @@ Site-wide footer. Three-column main row, two-row bottom bar.
         <div.language-selector> En ⌄
     <div.footer-bottom>
       <div.footer-bottom-left>
-        <Link.copyright> © 2025 DrumScore       ← links to /business-information
+        <Link.copyright> © {{year}} GrooveSheet ← links to /business-information
         <div.footer-legal> Terms / Privacy / Refund
 ```
 
@@ -47,15 +47,15 @@ Facebook, Instagram, X, YouTube, TikTok, Reddit, GitHub, LinkedIn, Discord, Dev.
 
 - Column headings in **Title Case** ("Explore", "Apps")
 - Link text in Title Case ("Pricing", "Desktop App")
-- Copyright reads `© 2025 DrumScore` — legacy brand name, intentional, links to `/business-information`
+- Copyright reads `© {{year}} GrooveSheet` (i18n key `footer.copyright`), links to `/business-information`
 
 ## Do / Don't
 
 - **Do** add new social platforms by appending to the `socialIcons` array with `name`, `component` (Phosphor export name), and `href`.
 - **Do** keep `weight="fill"` for socials. UI-chrome icons elsewhere use `weight="regular"`.
-- **Don't** rename the copyright string casually. "DrumScore" is intentional legacy branding here.
+- **Don't** hardcode the copyright — it's the i18n string `footer.copyright` (`© {{year}} GrooveSheet`).
 - **Don't** add a background color — Footer sits on the same canvas as Header.
 
 ## Drift from generated spec
 
-`VISUAL_GUIDE.md` says the footer is "simple" with logo + 16 social icons + two columns + language; current FE matches that. The legacy copyright "DrumScore" is the documented divergence between brand (`GrooveSheet`) and codebase footer text.
+`VISUAL_GUIDE.md` says the footer is "simple" with logo + 16 social icons + two columns + language; current FE matches that. No divergence — the copyright now reads `GrooveSheet` (rebranded from the legacy "DrumScore" string).

--- a/design-system/components/Header.md
+++ b/design-system/components/Header.md
@@ -65,6 +65,6 @@ The site-wide top navigation. Transparent over the dot grid; floats in document 
 
 ## Drift from generated spec
 
-- Logo `alt` text reads **"DrumScore Logo"** in source (legacy name); brand is GrooveSheet everywhere new is written. Don't rely on alt text for branding.
+- Logo `alt` text reads **"GrooveSheet Logo"** in source. Don't rely on alt text for branding.
 - `preview/component-menu.html` shows a single horizontal nav strip; the real header has a parallel mobile menu portal that matters for any nav change.
 - Generated visual guide describes "the brand mark" but Header swaps PNG logos by theme — no SVG mark used here. Production logos live in `public/images/Logo_White.png` and `public/images/Logo_Dark.png`, **not** in `design-system/assets/logos/`.

--- a/design-system/components/LegalPage.md
+++ b/design-system/components/LegalPage.md
@@ -54,7 +54,7 @@ Four sibling pages (`/privacy-policy`, `/refund-policy`, `/terms`, `/business-in
 
 - **Do** mirror the structure exactly when adding a new legal page (e.g., Cookie Policy). Copy `PrivacyPolicy.js` as the template.
 - **Do** consider extracting a shared `<LegalPage title="...">{children}</LegalPage>` component if a 5th legal page lands — the four current files duplicate Header/Footer/main wrapping logic.
-- **Don't** rebrand legacy entity names ("DrumScore" footer copyright, etc.) without legal review.
+- **Don't** alter the registered legal entity name (`USEFOOL TECHNOLOGY PRIVATE LIMITED`) or business-registration details on the Business Information page without legal review.
 - **Don't** mix the numbered-section style with plain-paragraph style on a single page (Privacy uses numbered; Business uses plain — pick one).
 
 ## Drift from generated spec

--- a/public/design/not-found.html
+++ b/public/design/not-found.html
@@ -55,7 +55,7 @@
 </style>
 </head>
 <body>
-<div style="position: relative; min-height: 100vh; width: 100%; overflow: hidden; background: #171717; font-family: var(--font-family-sans);">
+<div style="position: relative; min-height: 640px; width: 100%; overflow: hidden; background: #171717; font-family: var(--font-family-sans);">
 
   <!-- signature dot grid -->
   <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, #171E43 1.5px, transparent 1.5px); background-size: 43px 43px; opacity: 0.55; pointer-events: none;"></div>
@@ -73,21 +73,8 @@
     <div style="position:absolute; bottom:-40px; left:46%; --gs-dx:30px;  --gs-rot:16deg;  color:rgba(1,47,167,0.65); animation: gs404-drift 15s linear -11s infinite;"><svg width="30" height="42" viewBox="0 0 30 42" fill="none" xmlns="http://www.w3.org/2000/svg"><ellipse cx="8" cy="33" rx="8" ry="6" transform="rotate(-20 8 33)" fill="currentColor"/><rect x="15" y="6" width="2.6" height="27" fill="currentColor"/><path d="M17 6c6 2 9 6 8 13-1-5-5-7-8-7z" fill="currentColor"/></svg></div>
   </div>
 
-  <!-- header -->
-  <header style="position: relative; z-index: 10; display: flex; align-items: center; justify-content: space-between; max-width: 1414px; margin: 0 auto; padding: 32px 40px;">
-    <a href="/" target="_top" style="display: flex; align-items: center; gap: 12px; text-decoration: none;">
-      <span style="display: inline-flex; align-items: center; justify-content: center; width: 34px; height: 34px; border-radius: 8px; background: #012FA7;"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 18V6l10-2v12" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6" cy="18" r="3" fill="#fff"/><circle cx="16" cy="16" r="3" fill="#fff"/></svg></span>
-      <span style="font-size: 20px; font-weight: 500; letter-spacing: -0.3px; color: #F4F4F4;">GrooveSheet</span>
-    </a>
-    <nav style="display: flex; align-items: center; gap: 32px;">
-      <a href="/pricing" target="_top" class="gs404-navlink" style="font-size: 15px; color: #8D8C8D; text-decoration: none;">Pricing</a>
-      <a href="/about" target="_top" class="gs404-navlink" style="font-size: 15px; color: #8D8C8D; text-decoration: none;">About</a>
-      <a href="/" target="_top" style="font-size: 14px; font-weight: 500; color: #F4F4F4; text-decoration: none; padding: 10px 20px; border-radius: 120px; border: 1px solid rgba(255,255,255,0.18);" target="_top">Sign in</a>
-    </nav>
-  </header>
-
   <!-- main -->
-  <main style="position: relative; z-index: 10; display: flex; flex-direction: column; align-items: center; text-align: center; padding: 40px 20px 90px; max-width: 720px; margin: 0 auto;">
+  <main style="position: relative; z-index: 10; display: flex; flex-direction: column; align-items: center; text-align: center; padding: 96px 20px 90px; max-width: 720px; margin: 0 auto;">
 
     <!-- eyebrow -->
     <div style="opacity: 0; animation: gs404-fadeup .6s ease .05s forwards; display: inline-flex; align-items: center; gap: 10px; margin-bottom: 34px; padding: 7px 14px 7px 12px; border-radius: 120px; background: #212121;">

--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Header from './layout/Header';
+import Footer from './layout/Footer';
 
 /**
  * 404 Not Found — catch-all route.
  *
- * Embeds the finished Claude Design (404.dc.html) as a self-contained static
- * page at public/design/not-found.html. It's rendered in an iframe so the
- * design's own typography and animations are fully isolated from the app's
- * global CSS (App.css forces `font-family !important` and a 1.2s `transition`
- * on every element, which would otherwise override the design).
+ * The animated 404 artwork is the finished Claude Design (404.dc.html), served
+ * as a self-contained static page at public/design/not-found.html and rendered
+ * in an iframe so the design's own typography and animations stay isolated from
+ * the app's global CSS (App.css forces `font-family !important` and a 1.2s
+ * `transition` on every element, which would otherwise override the design).
+ *
+ * The iframe holds only the hero artwork — the real site Header and Footer wrap
+ * it so the 404 reads as a normal page. The iframe flexes to fill the space
+ * between them (its own header/footer were removed from the static file).
  *
  * Links inside the design use target="_top" so they navigate the parent window.
  *
@@ -15,24 +21,42 @@ import React from 'react';
  * params; the design reads them with textContent, so plain text only) —
  * lets routes like /explore/:songId reuse this page for "Track not found".
  */
-function NotFound({ title, body }) {
+function NotFound({ title, body, onLoginClick }) {
   const params = new URLSearchParams();
   if (title) params.set('title', title);
   if (body) params.set('body', body);
   const query = params.toString();
+
+  // Auto-size the iframe to its content so the real Footer sits directly below
+  // the artwork with no gap. Same-origin, so we can read the inner document.
+  const frameRef = useRef(null);
+  const [frameHeight, setFrameHeight] = useState(640);
+  const syncHeight = useCallback(() => {
+    const doc = frameRef.current && frameRef.current.contentDocument;
+    if (doc && doc.documentElement) setFrameHeight(doc.documentElement.scrollHeight);
+  }, []);
+  useEffect(() => {
+    window.addEventListener('resize', syncHeight);
+    return () => window.removeEventListener('resize', syncHeight);
+  }, [syncHeight]);
+
   return (
-    <iframe
-      title="Page not found"
-      src={`${process.env.PUBLIC_URL}/design/not-found.html${query ? `?${query}` : ''}`}
-      style={{
-        position: 'fixed',
-        inset: 0,
-        width: '100%',
-        height: '100%',
-        border: 'none',
-        display: 'block',
-      }}
-    />
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Header onLoginClick={onLoginClick} />
+      <iframe
+        ref={frameRef}
+        onLoad={syncHeight}
+        title={title || 'Page not found'}
+        src={`${process.env.PUBLIC_URL}/design/not-found.html${query ? `?${query}` : ''}`}
+        style={{
+          width: '100%',
+          height: frameHeight,
+          border: 'none',
+          display: 'block',
+        }}
+      />
+      <Footer />
+    </div>
   );
 }
 

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -76,7 +76,7 @@ function Header({ onLoginClick }) {
             <LocalizedLink to="/" className="logo">
               <img
                 src={isDarkMode ? '/images/Logo_White.png' : '/images/Logo_Dark.png'}
-                alt="DrumScore Logo"
+                alt="GrooveSheet Logo"
                 className="logo-image"
               />
             </LocalizedLink>

--- a/src/components/video/VideoDrumKit.js
+++ b/src/components/video/VideoDrumKit.js
@@ -24,7 +24,7 @@ const IMG_W = 1200;
 const IMG_H = 562;
 
 const HOLD_SEC = 0.09; // overlay stays solid blue for this long after a hit
-const FLASH_SEC = 0.26; // total flash length (hold + fade-out)
+const FLASH_SEC = 0.16; // total flash length (hold + fade-out)
 const MIN_ALPHA = 0.0; // overlays fully invisible at rest
 
 // One entry per kit piece. GM channel-10 note numbers → piece, mirroring the

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@
 
 const config = {
   // Application Configuration
-  appName: process.env.REACT_APP_NAME || 'DrumScore',
+  appName: process.env.REACT_APP_NAME || 'GrooveSheet',
   appUrl: process.env.REACT_APP_URL || 'http://localhost:3000',
 
   // API Configuration

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -38,7 +38,7 @@
     "desktopApp": "Desktop App",
     "iosApp": "iOS App",
     "androidApp": "Android App",
-    "copyright": "© {{year}} DrumScore",
+    "copyright": "© {{year}} GrooveSheet",
     "terms": "Terms & Conditions",
     "privacy": "Privacy Policy",
     "refund": "Refund Policy"
@@ -250,10 +250,10 @@
     }
   },
   "login": {
-    "welcome": "Welcome to DrumScore",
+    "welcome": "Welcome to GrooveSheet",
     "continueWith": "Continue with",
-    "subscribeLong": "Subscribe to DrumScore updates and never miss a beat!",
-    "subscribeShort": "Subscribe to DrumScore updates",
+    "subscribeLong": "Subscribe to GrooveSheet updates and never miss a beat!",
+    "subscribeShort": "Subscribe to GrooveSheet updates",
     "google": "Google",
     "facebook": "Facebook",
     "apple": "Apple",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -38,7 +38,7 @@
     "desktopApp": "桌面端",
     "iosApp": "iOS 应用",
     "androidApp": "Android 应用",
-    "copyright": "© {{year}} DrumScore",
+    "copyright": "© {{year}} GrooveSheet",
     "terms": "服务条款",
     "privacy": "隐私政策",
     "refund": "退款政策"
@@ -250,10 +250,10 @@
     }
   },
   "login": {
-    "welcome": "欢迎使用 DrumScore",
+    "welcome": "欢迎使用 GrooveSheet",
     "continueWith": "使用以下方式继续",
-    "subscribeLong": "订阅 DrumScore 更新,不错过任何节奏!",
-    "subscribeShort": "订阅 DrumScore 更新",
+    "subscribeLong": "订阅 GrooveSheet 更新,不错过任何节奏!",
+    "subscribeShort": "订阅 GrooveSheet 更新",
     "google": "Google",
     "facebook": "Facebook",
     "apple": "Apple",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -38,7 +38,7 @@
     "desktopApp": "桌面版",
     "iosApp": "iOS 應用程式",
     "androidApp": "Android 應用程式",
-    "copyright": "© {{year}} DrumScore",
+    "copyright": "© {{year}} GrooveSheet",
     "terms": "服務條款",
     "privacy": "隱私政策",
     "refund": "退款政策"
@@ -250,10 +250,10 @@
     }
   },
   "login": {
-    "welcome": "歡迎使用 DrumScore",
+    "welcome": "歡迎使用 GrooveSheet",
     "continueWith": "以下列方式繼續",
-    "subscribeLong": "訂閱 DrumScore 更新,不錯過任何節奏!",
-    "subscribeShort": "訂閱 DrumScore 更新",
+    "subscribeLong": "訂閱 GrooveSheet 更新,不錯過任何節奏!",
+    "subscribeShort": "訂閱 GrooveSheet 更新",
     "google": "Google",
     "facebook": "Facebook",
     "apple": "Apple",

--- a/src/lib/constants/index.js
+++ b/src/lib/constants/index.js
@@ -6,7 +6,7 @@
 export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3000/api';
 
 // Application metadata
-export const APP_NAME = 'DrumScore';
+export const APP_NAME = 'GrooveSheet';
 export const APP_DESCRIPTION = 'High-quality drum notation generation with AI-powered technology';
 
 // Navigation links
@@ -19,10 +19,10 @@ export const NAV_LINKS = [
 
 // Social media links
 export const SOCIAL_LINKS = {
-  twitter: 'https://twitter.com/drumscore',
-  facebook: 'https://facebook.com/drumscore',
-  instagram: 'https://instagram.com/drumscore',
-  linkedin: 'https://linkedin.com/company/drumscore',
+  twitter: 'https://twitter.com/groovesheet',
+  facebook: 'https://facebook.com/groovesheet',
+  instagram: 'https://instagram.com/groovesheet',
+  linkedin: 'https://linkedin.com/company/groovesheet',
 };
 
 // Pricing tiers (example - update with actual data)


### PR DESCRIPTION
## Summary
- **404 page**: now renders inside the real GrooveSheet `Header`/`Footer` (both the catch-all route and the missing-track page). The animated artwork stays in an iframe (CSS isolation) but auto-sizes to its content; its own fake header/nav was removed and top spacing increased.
- **Rebrand**: replaced remaining user-facing `DrumScore` → `GrooveSheet` — footer copyright, welcome/subscribe strings (en/zh-CN/zh-TW), logo alt text, `config.appName`, unused `lib/constants`, README, `.env.example`, and the design-system spec docs.
  - Backend API workflow tokens (`separate_to_drumscore*`) left unchanged — API contract.
- **video2**: shortened drum-kit visualizer flash duration (0.26s → 0.16s).

## Verification
Verified the 404 in the dev preview: real header + footer wrap the artwork, no gaps, footer copyright now reads "© 2026 GrooveSheet". No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)