### PR TITLE
fix(video2): regenerate drum sample MusicXML with proper kit notation

### DIFF
--- a/public/transcription-samples/ado-mirror/adtof-drums/ADT250444bafd56_drum_transcription.musicxml
+++ b/public/transcription-samples/ado-mirror/adtof-drums/ADT250444bafd56_drum_transcription.musicxml
@@ -5,7 +5,7 @@
   <identification>
     <creator type="composer">Music21</creator>
     <encoding>
-      <encoding-date>2026-07-03</encoding-date>
+      <encoding-date>2026-07-05</encoding-date>
       <software>music21 v.10.5.0</software>
       <supports element="beam" type="yes" />
       <supports element="stem" type="yes" />
@@ -19,21 +19,21 @@
     </scaling>
   </defaults>
   <part-list>
-    <score-part id="P276a249c0d069afb45d5b86b511def9d">
+    <score-part id="P469f1f95c53f2155843d8fb20da73a98">
       <part-name>Percussion</part-name>
       <part-abbreviation>Perc</part-abbreviation>
-      <score-instrument id="I1ea9218b61ca444f1b01ac9b03d5cef3">
+      <score-instrument id="I1bd0f4810353e74817f26f7bbfd7b24a">
         <instrument-name>Percussion</instrument-name>
         <instrument-abbreviation>Perc</instrument-abbreviation>
       </score-instrument>
-      <midi-instrument id="I1ea9218b61ca444f1b01ac9b03d5cef3">
+      <midi-instrument id="I1bd0f4810353e74817f26f7bbfd7b24a">
         <midi-channel>10</midi-channel>
         <midi-program>2</midi-program>
       </midi-instrument>
     </score-part>
   </part-list>
   <!--=========================== Part 1 ===========================-->
-  <part id="P276a249c0d069afb45d5b86b511def9d">
+  <part id="P469f1f95c53f2155843d8fb20da73a98">
     <!--========================= Measure 1 ==========================-->
     <measure implicit="no" number="1">
       <attributes>
@@ -43,8 +43,7 @@
           <beat-type>4</beat-type>
         </time>
         <clef>
-          <sign>G</sign>
-          <line>2</line>
+          <sign>percussion</sign>
         </clef>
       </attributes>
       <direction>
@@ -93,7 +92,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -102,20 +101,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -127,11 +128,12 @@
     <measure implicit="no" number="6">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -140,7 +142,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -149,11 +151,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -162,8 +165,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -172,6 +175,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -188,8 +192,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -198,12 +202,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -229,11 +234,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -242,16 +248,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -264,11 +271,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -277,16 +285,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -307,8 +316,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -317,6 +326,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -342,7 +352,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -359,8 +369,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -369,6 +379,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -377,28 +388,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -411,8 +424,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -421,6 +434,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -446,8 +460,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -456,6 +470,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -463,7 +478,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -481,8 +496,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -491,6 +506,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -507,8 +523,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -517,6 +533,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -530,8 +547,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -540,6 +557,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -547,7 +565,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -585,8 +603,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -595,6 +613,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -611,7 +630,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -638,8 +657,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -648,11 +667,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -661,6 +681,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -678,16 +699,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -700,11 +722,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -713,8 +736,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -723,6 +746,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -740,7 +764,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -758,8 +782,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -768,6 +792,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -785,8 +810,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -795,11 +820,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -808,6 +834,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -816,8 +843,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -826,13 +853,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 9 ==========================-->
     <measure implicit="no" number="9">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -845,11 +873,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -858,7 +887,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -884,8 +913,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -894,6 +923,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -907,8 +937,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -917,22 +947,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -945,7 +977,40 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -958,51 +1023,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1014,7 +1050,17 @@
     <measure implicit="no" number="10">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1023,29 +1069,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1054,8 +1093,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1064,6 +1103,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1085,7 +1125,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1123,11 +1163,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1136,8 +1177,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1146,6 +1187,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1162,7 +1204,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1185,8 +1227,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1195,6 +1237,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -1206,16 +1249,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1231,8 +1275,8 @@
     <measure implicit="no" number="11">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1241,6 +1285,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -1257,8 +1302,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1267,12 +1312,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1298,11 +1344,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1311,7 +1358,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1320,11 +1367,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1333,8 +1381,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1343,6 +1391,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -1359,8 +1408,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1369,12 +1418,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1400,20 +1450,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1422,16 +1474,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1447,20 +1500,22 @@
     <measure implicit="no" number="12">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1469,16 +1524,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1491,11 +1547,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1504,7 +1561,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1513,11 +1570,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1526,8 +1584,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1536,6 +1594,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1561,8 +1620,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1571,6 +1630,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -1582,8 +1642,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1592,6 +1652,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1617,8 +1678,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1627,6 +1688,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -1634,7 +1696,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1655,41 +1717,45 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1698,7 +1764,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1724,8 +1790,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1734,6 +1800,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -1751,7 +1818,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1760,11 +1827,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1773,18 +1841,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1793,6 +1862,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -1811,7 +1881,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1829,8 +1899,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1839,6 +1909,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1855,8 +1926,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1865,6 +1936,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1884,16 +1956,17 @@
     <measure implicit="no" number="14">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1906,20 +1979,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1928,8 +2003,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1938,6 +2013,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1954,7 +2030,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1968,8 +2044,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1978,6 +2054,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1991,8 +2068,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2001,6 +2078,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -2012,7 +2090,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2038,8 +2116,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2048,6 +2126,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2061,8 +2140,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2071,22 +2150,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2099,11 +2180,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2115,16 +2197,17 @@
     <measure implicit="no" number="15">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2137,11 +2220,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2150,16 +2234,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2172,8 +2257,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2182,6 +2267,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -2203,7 +2289,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2229,8 +2315,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2239,6 +2325,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2255,28 +2342,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2289,28 +2378,30 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 16 =========================-->
     <measure implicit="no" number="16">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -2319,6 +2410,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -2335,8 +2427,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -2345,6 +2437,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2383,8 +2476,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2393,6 +2486,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -2400,7 +2494,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2435,8 +2529,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2445,6 +2539,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -2452,8 +2547,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2462,6 +2557,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2470,8 +2566,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2480,6 +2576,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -2496,7 +2593,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2510,8 +2607,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2520,6 +2617,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2536,11 +2634,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2549,7 +2648,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2558,11 +2657,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2571,11 +2671,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2584,11 +2685,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2600,11 +2702,12 @@
     <measure implicit="no" number="17">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2613,16 +2716,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2635,8 +2739,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2645,6 +2749,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -2662,8 +2767,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2672,11 +2777,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2685,13 +2791,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2700,6 +2807,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2716,7 +2824,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2729,11 +2837,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2742,7 +2851,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2769,8 +2878,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2779,6 +2888,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2787,8 +2897,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2797,6 +2907,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -2813,8 +2924,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2823,6 +2934,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -2831,7 +2943,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2852,16 +2964,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2874,42 +3011,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2918,11 +3035,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2944,7 +3062,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2970,8 +3088,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2980,12 +3098,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2994,6 +3113,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3007,8 +3127,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3017,6 +3137,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -3028,7 +3149,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3037,11 +3158,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3050,27 +3172,29 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 20 =========================-->
     <measure implicit="no" number="20">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3083,11 +3207,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3096,16 +3221,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3118,11 +3244,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3131,16 +3258,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3153,11 +3281,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3166,7 +3295,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3175,11 +3304,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3191,28 +3321,30 @@
     <measure implicit="no" number="21">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3225,8 +3357,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3235,6 +3367,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3252,8 +3385,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3262,6 +3395,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3270,8 +3404,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3280,6 +3414,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3296,7 +3431,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3319,8 +3454,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3329,6 +3464,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -3337,8 +3473,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3347,11 +3483,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3360,6 +3497,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -3377,7 +3515,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3400,8 +3538,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3410,6 +3548,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -3438,7 +3577,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3455,8 +3594,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3465,6 +3604,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 22 =========================-->
@@ -3477,30 +3617,32 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3515,17 +3657,45 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
       </note>
       <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3540,47 +3710,24 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3590,12 +3737,13 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3610,8 +3758,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -3621,6 +3769,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3635,7 +3784,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -3652,8 +3801,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <voice>1</voice>
@@ -3663,10 +3812,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -3684,8 +3834,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <voice>1</voice>
@@ -3695,6 +3845,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <backup>
         <duration>40320</duration>
@@ -3712,8 +3863,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -3723,11 +3874,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3750,7 +3902,7 @@
     <measure implicit="no" number="23">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -3776,8 +3928,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -3786,6 +3938,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3824,8 +3977,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3834,6 +3987,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -3841,8 +3995,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3851,6 +4005,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -3869,7 +4024,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3887,20 +4042,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3909,8 +4066,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3919,6 +4076,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3936,7 +4094,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3954,8 +4112,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3964,6 +4122,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3980,8 +4139,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3990,6 +4149,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4006,7 +4166,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4015,20 +4185,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4037,11 +4199,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4053,7 +4216,7 @@
     <measure implicit="no" number="24">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4062,11 +4225,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4075,11 +4239,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4088,8 +4253,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4098,6 +4263,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4114,7 +4280,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4137,8 +4303,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4147,14 +4313,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4163,6 +4330,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4179,7 +4347,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4202,8 +4370,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4212,22 +4380,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4240,11 +4410,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 25 =========================-->
@@ -4256,7 +4427,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4265,11 +4436,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4278,16 +4450,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4296,6 +4469,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4312,7 +4486,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4335,8 +4509,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4345,6 +4519,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4352,8 +4527,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4362,6 +4537,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4370,38 +4546,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4414,16 +4569,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4439,11 +4619,12 @@
     <measure implicit="no" number="26">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4452,7 +4633,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4479,8 +4660,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4489,6 +4670,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4497,8 +4679,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4507,6 +4689,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4523,7 +4706,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4549,11 +4732,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4562,16 +4746,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4584,47 +4769,51 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4645,8 +4834,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4655,6 +4844,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4680,7 +4870,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4697,8 +4887,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4707,6 +4897,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4715,28 +4906,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4749,8 +4942,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4759,6 +4952,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4775,8 +4969,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4785,6 +4979,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4798,8 +4993,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4808,6 +5003,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4815,7 +5011,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4833,8 +5029,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4843,6 +5039,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4868,8 +5065,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4878,6 +5075,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4923,8 +5121,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4975,7 +5173,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4984,11 +5182,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4997,7 +5196,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5006,11 +5205,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5019,11 +5219,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 32 =========================-->
@@ -5035,8 +5236,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5045,8 +5246,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5056,7 +5257,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5065,11 +5266,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5078,7 +5280,21 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5091,21 +5307,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5114,6 +5317,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5139,8 +5343,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5149,11 +5353,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5166,8 +5371,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5176,6 +5381,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5204,8 +5410,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5214,6 +5420,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5221,7 +5428,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5259,8 +5466,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5269,6 +5476,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5282,8 +5490,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5292,6 +5500,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5299,7 +5508,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5317,8 +5526,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5327,6 +5536,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5355,7 +5565,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5364,11 +5574,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5377,28 +5588,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5414,16 +5627,17 @@
     <measure implicit="no" number="34">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5436,20 +5650,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5458,8 +5674,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5468,6 +5684,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5484,7 +5701,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5507,8 +5724,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5517,6 +5734,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5528,7 +5746,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5554,8 +5772,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5564,6 +5782,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5577,8 +5796,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5587,22 +5806,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5615,11 +5836,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5631,8 +5853,8 @@
     <measure implicit="no" number="35">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5641,6 +5863,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5657,7 +5880,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5680,8 +5903,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5690,6 +5913,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5697,8 +5921,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5707,11 +5931,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5720,6 +5945,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5737,8 +5963,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5747,10 +5973,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5774,8 +6001,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5784,6 +6011,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5795,7 +6023,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5821,8 +6049,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5831,6 +6059,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5847,28 +6076,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5881,12 +6112,13 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="start" />
         </notations>
@@ -5896,8 +6128,8 @@
     <measure implicit="no" number="36">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -5907,6 +6139,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="stop" />
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5958,8 +6191,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5968,6 +6201,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5975,7 +6209,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6010,8 +6244,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6020,6 +6254,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6027,8 +6262,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6037,6 +6272,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6045,8 +6281,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6055,6 +6291,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6116,7 +6353,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6125,20 +6362,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6147,11 +6386,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6160,7 +6400,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6191,8 +6431,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6201,6 +6441,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -6217,8 +6458,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6227,6 +6468,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -6235,7 +6477,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6257,8 +6499,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6267,6 +6509,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6284,7 +6527,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6302,8 +6545,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6312,6 +6555,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6340,16 +6584,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6362,11 +6607,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6375,7 +6621,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6384,11 +6630,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6397,28 +6644,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6429,8 +6678,8 @@
     <measure implicit="no" number="39">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -6439,6 +6688,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6455,7 +6705,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -6503,8 +6753,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6513,6 +6763,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6542,16 +6793,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6564,20 +6816,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6586,8 +6840,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6596,6 +6850,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6612,7 +6867,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6635,8 +6890,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6645,6 +6900,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6656,7 +6912,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6665,11 +6921,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6678,19 +6935,20 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 40 =========================-->
     <measure implicit="no" number="40">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6699,6 +6957,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6715,7 +6974,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6738,8 +6997,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6748,6 +7007,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6759,8 +7019,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6769,6 +7029,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6785,7 +7046,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6808,8 +7069,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6818,12 +7079,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6832,11 +7094,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6845,6 +7108,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -6853,8 +7117,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6863,10 +7127,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6905,11 +7170,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6918,7 +7184,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6927,11 +7193,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6943,28 +7210,30 @@
     <measure implicit="no" number="41">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6977,8 +7246,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6987,6 +7256,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7004,8 +7274,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7014,6 +7284,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7022,8 +7293,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7032,6 +7303,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7048,7 +7320,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7071,8 +7343,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7081,6 +7353,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -7089,8 +7362,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7099,11 +7372,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7112,6 +7386,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -7129,7 +7404,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7143,8 +7418,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7153,12 +7428,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7167,6 +7443,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7180,8 +7457,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7190,6 +7467,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -7218,7 +7496,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7235,8 +7513,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7245,6 +7523,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 42 =========================-->
@@ -7256,28 +7535,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7290,28 +7571,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7324,8 +7607,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7334,6 +7617,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7359,8 +7643,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7369,11 +7653,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7399,8 +7684,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7409,6 +7694,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7434,7 +7720,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -7450,8 +7736,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -7460,10 +7746,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -7483,8 +7770,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -7493,13 +7780,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 43 =========================-->
     <measure implicit="no" number="43">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -7525,8 +7813,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -7535,6 +7823,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7573,8 +7862,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7583,6 +7872,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -7590,8 +7880,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7600,6 +7890,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -7618,7 +7909,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7636,20 +7927,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7658,8 +7951,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7668,6 +7961,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7685,7 +7979,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7703,8 +7997,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7713,6 +8007,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7729,8 +8024,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7739,6 +8034,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7755,16 +8051,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7777,11 +8074,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7793,7 +8091,7 @@
     <measure implicit="no" number="44">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7802,11 +8100,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7815,11 +8114,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7828,16 +8128,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7850,20 +8151,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7872,16 +8175,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7894,45 +8198,49 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7945,11 +8253,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 45 =========================-->
@@ -7961,7 +8270,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7970,11 +8279,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7983,17 +8293,126 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+        <notations>
+          <tuplet bracket="yes" number="1" placement="above" type="start">
+            <tuplet-actual>
+              <tuplet-number>3</tuplet-number>
+              <tuplet-type>eighth</tuplet-type>
+            </tuplet-actual>
+            <tuplet-normal>
+              <tuplet-number>2</tuplet-number>
+              <tuplet-type>eighth</tuplet-type>
+            </tuplet-normal>
+          </tuplet>
+        </notations>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <rest />
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+        <notations>
+          <tuplet number="1" type="stop" />
+        </notations>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
         <duration>3360</duration>
         <type>eighth</type>
         <time-modification>
@@ -8015,49 +8434,8 @@
         </notations>
       </note>
       <note>
-        <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <rest />
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <notations>
-          <tuplet number="1" type="stop" />
-        </notations>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8071,8 +8449,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8081,12 +8459,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8095,69 +8474,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <rest />
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <notations>
-          <tuplet bracket="yes" number="1" placement="above" type="start">
-            <tuplet-actual>
-              <tuplet-number>3</tuplet-number>
-              <tuplet-type>eighth</tuplet-type>
-            </tuplet-actual>
-            <tuplet-normal>
-              <tuplet-number>2</tuplet-number>
-              <tuplet-type>eighth</tuplet-type>
-            </tuplet-normal>
-          </tuplet>
-        </notations>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8174,7 +8491,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8183,11 +8500,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8196,7 +8514,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8205,20 +8523,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8230,11 +8550,12 @@
     <measure implicit="no" number="46">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8243,7 +8564,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8252,11 +8573,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8265,8 +8587,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8275,6 +8597,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8291,8 +8614,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8301,12 +8624,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8332,11 +8656,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8345,16 +8670,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8367,11 +8693,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8380,16 +8707,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8410,8 +8738,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8420,6 +8748,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8445,7 +8774,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8462,8 +8791,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8472,6 +8801,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8480,28 +8810,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8514,8 +8846,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8524,6 +8856,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8549,8 +8882,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8559,6 +8892,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -8566,7 +8900,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8584,8 +8918,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8594,6 +8928,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8619,8 +8954,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8629,6 +8964,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -8636,7 +8972,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8674,8 +9010,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8684,6 +9020,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8700,7 +9037,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8727,8 +9064,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8737,11 +9074,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8750,6 +9088,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -8767,16 +9106,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8789,20 +9129,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8811,8 +9153,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8821,6 +9163,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8838,7 +9181,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8856,8 +9199,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8866,6 +9209,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8883,8 +9227,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8893,11 +9237,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8906,6 +9251,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -8916,16 +9262,17 @@
     <measure implicit="no" number="49">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8938,11 +9285,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8951,7 +9299,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8977,8 +9325,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8987,6 +9335,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9000,8 +9349,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9010,22 +9359,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9038,16 +9389,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9060,42 +9436,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9112,7 +9468,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9121,20 +9477,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9143,8 +9501,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9153,6 +9511,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9174,7 +9533,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9212,11 +9571,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9225,16 +9585,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9247,28 +9608,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9284,8 +9647,8 @@
     <measure implicit="no" number="51">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9294,6 +9657,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -9310,8 +9674,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9320,12 +9684,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9351,11 +9716,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9364,7 +9730,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9373,11 +9739,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9386,8 +9753,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9396,6 +9763,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -9412,8 +9780,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9422,12 +9790,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9453,11 +9822,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9466,7 +9836,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9475,20 +9855,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9500,20 +9872,22 @@
     <measure implicit="no" number="52">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9522,16 +9896,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9544,11 +9919,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9557,7 +9933,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9566,11 +9942,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9579,8 +9956,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9589,6 +9966,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9614,8 +9992,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9624,6 +10002,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -9631,7 +10010,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9649,8 +10028,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9659,6 +10038,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9675,8 +10055,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9685,6 +10065,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9698,8 +10079,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9708,6 +10089,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -9715,7 +10097,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9736,41 +10118,45 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9779,7 +10165,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9805,8 +10191,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9815,6 +10201,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -9832,7 +10219,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9841,11 +10228,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9854,18 +10242,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9874,6 +10263,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -9892,7 +10282,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9910,8 +10300,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9920,6 +10310,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9951,7 +10342,17 @@
     <measure implicit="no" number="54">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9960,20 +10361,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9982,20 +10375,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10004,8 +10399,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10014,6 +10409,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10030,7 +10426,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10044,8 +10440,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10054,6 +10450,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10067,8 +10464,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10077,6 +10474,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10088,7 +10486,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10114,8 +10512,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10124,6 +10522,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10137,8 +10536,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10147,22 +10546,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10175,20 +10576,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10200,16 +10603,17 @@
     <measure implicit="no" number="55">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10222,11 +10626,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10235,16 +10640,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10257,8 +10663,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10267,6 +10673,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10288,7 +10695,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10314,8 +10721,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10324,6 +10731,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10340,28 +10748,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10374,28 +10784,30 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 56 =========================-->
     <measure implicit="no" number="56">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -10404,6 +10816,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10420,8 +10833,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -10430,6 +10843,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10468,8 +10882,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10478,6 +10892,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10485,7 +10900,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10499,8 +10914,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10509,6 +10924,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10534,8 +10950,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10544,6 +10960,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10551,8 +10968,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10561,6 +10978,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10569,8 +10987,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10579,6 +10997,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10595,7 +11014,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10621,11 +11040,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10634,7 +11054,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10643,11 +11063,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10656,11 +11077,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10669,16 +11091,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10694,7 +11117,41 @@
     <measure implicit="no" number="57">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10703,8 +11160,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10716,39 +11173,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10757,6 +11183,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -10774,8 +11201,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10784,11 +11211,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10797,13 +11225,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10812,6 +11241,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10828,7 +11258,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10841,11 +11271,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10854,7 +11285,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10881,8 +11312,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10895,8 +11326,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10905,6 +11336,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10913,8 +11345,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10923,6 +11355,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -10939,8 +11372,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10949,6 +11382,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -10957,7 +11391,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10978,16 +11412,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11000,42 +11459,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11044,8 +11483,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11054,6 +11493,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11124,7 +11564,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11141,8 +11581,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11151,12 +11591,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11165,6 +11606,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11191,7 +11633,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11200,11 +11642,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11216,28 +11659,30 @@
     <measure implicit="no" number="61">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11250,8 +11695,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11260,6 +11705,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11281,8 +11727,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11291,6 +11737,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11307,7 +11754,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11330,8 +11777,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11340,6 +11787,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -11347,8 +11795,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11357,6 +11805,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -11374,7 +11823,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11397,8 +11846,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11407,6 +11856,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -11435,7 +11885,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11452,8 +11902,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11462,6 +11912,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 62 =========================-->
@@ -11473,28 +11924,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11507,11 +11960,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11520,16 +11974,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11542,8 +11997,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11552,6 +12007,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11568,8 +12024,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11578,6 +12034,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11591,8 +12048,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11601,6 +12058,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -11608,7 +12066,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11643,8 +12101,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11653,6 +12111,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11669,7 +12128,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11678,18 +12137,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 63 =========================-->
     <measure implicit="no" number="63">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -11715,8 +12175,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -11725,6 +12185,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11763,8 +12224,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11773,6 +12234,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -11780,8 +12242,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11790,6 +12252,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -11808,7 +12271,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11826,11 +12289,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11839,8 +12303,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11849,6 +12313,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11866,7 +12331,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11884,8 +12349,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11894,6 +12359,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -11911,8 +12377,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11921,11 +12387,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11934,6 +12401,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -11942,8 +12410,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11952,10 +12420,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11968,11 +12437,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11984,7 +12454,7 @@
     <measure implicit="no" number="64">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11993,11 +12463,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12006,7 +12477,31 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12019,16 +12514,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12041,20 +12561,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12063,7 +12585,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12072,64 +12604,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12138,11 +12618,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 65 =========================-->
@@ -12154,7 +12635,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12163,11 +12644,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12176,16 +12658,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12194,6 +12677,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12210,7 +12694,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12233,8 +12717,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12243,6 +12727,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -12250,8 +12735,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12260,6 +12745,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12268,16 +12754,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12290,28 +12777,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12327,11 +12816,12 @@
     <measure implicit="no" number="66">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12340,7 +12830,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12349,11 +12839,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12362,8 +12853,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12372,6 +12863,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -12388,8 +12880,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12398,12 +12890,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12429,7 +12922,31 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12442,20 +12959,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12464,38 +12983,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12516,8 +13014,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12526,6 +13024,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12551,7 +13050,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12568,8 +13067,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12578,6 +13077,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12586,28 +13086,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12620,11 +13122,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12633,7 +13136,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12646,45 +13149,49 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12701,7 +13208,7 @@
     <measure implicit="no" number="68">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -12763,8 +13270,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12773,6 +13280,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -12801,7 +13309,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12816,8 +13324,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12826,11 +13334,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12839,6 +13348,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -12869,16 +13379,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12891,20 +13402,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12913,8 +13426,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12923,6 +13436,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12940,7 +13454,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12954,8 +13468,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12964,6 +13478,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12972,8 +13487,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12982,6 +13497,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12998,8 +13514,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13008,6 +13524,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13027,8 +13544,8 @@
     <measure implicit="no" number="69">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13037,6 +13554,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -13054,7 +13572,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13068,8 +13586,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13078,11 +13596,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13108,8 +13627,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13134,7 +13653,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13148,8 +13667,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13158,12 +13677,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13172,6 +13692,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13185,8 +13706,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13195,14 +13716,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13211,6 +13733,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13227,7 +13750,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13250,8 +13773,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13260,22 +13783,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13288,27 +13813,29 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 70 =========================-->
     <measure implicit="no" number="70">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13321,8 +13848,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13331,6 +13858,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13352,7 +13880,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13378,8 +13906,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13388,6 +13916,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13404,7 +13933,31 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13417,20 +13970,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13439,7 +13994,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13448,11 +14013,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13461,59 +14027,30 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 71 =========================-->
     <measure implicit="no" number="71">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -13522,6 +14059,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13538,8 +14076,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -13548,6 +14086,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13586,8 +14125,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13596,6 +14135,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -13603,7 +14143,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13639,11 +14179,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13652,7 +14193,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13661,11 +14202,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13674,8 +14216,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13684,6 +14226,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -13700,8 +14243,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13710,12 +14253,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13741,20 +14285,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13763,7 +14309,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13772,20 +14328,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13797,8 +14345,8 @@
     <measure implicit="no" number="72">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13807,6 +14355,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -13824,8 +14373,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13834,11 +14383,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13847,13 +14397,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13862,10 +14413,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13887,11 +14439,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13900,7 +14453,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13909,11 +14462,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13922,8 +14476,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13932,6 +14486,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13957,8 +14512,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13967,11 +14522,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13984,8 +14540,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13994,6 +14550,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14022,8 +14579,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14032,6 +14589,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14039,7 +14597,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14060,20 +14618,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14082,7 +14642,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14091,29 +14661,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14122,11 +14685,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14135,7 +14699,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14144,11 +14708,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14157,28 +14722,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14191,11 +14758,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14207,16 +14775,17 @@
     <measure implicit="no" number="74">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14229,11 +14798,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14242,8 +14812,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14252,6 +14822,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -14268,7 +14839,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14291,8 +14862,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14301,6 +14872,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14312,7 +14884,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14338,8 +14910,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14348,6 +14920,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14361,8 +14934,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14371,22 +14944,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14399,19 +14974,20 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 75 =========================-->
     <measure implicit="no" number="75">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14420,6 +14996,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -14436,7 +15013,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14459,8 +15036,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14469,6 +15046,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14476,8 +15054,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14486,6 +15064,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14494,16 +15073,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14516,8 +15096,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14526,6 +15106,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -14547,7 +15128,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14573,8 +15154,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14583,6 +15164,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14599,28 +15181,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14633,12 +15217,13 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="start" />
         </notations>
@@ -14648,8 +15233,8 @@
     <measure implicit="no" number="76">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -14659,6 +15244,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="stop" />
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -14710,8 +15296,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14720,6 +15306,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14727,7 +15314,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14763,20 +15350,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14785,26 +15374,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14819,11 +15410,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14832,7 +15424,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14841,11 +15433,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14854,11 +15447,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14867,16 +15461,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14892,8 +15487,8 @@
     <measure implicit="no" number="77">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14902,6 +15497,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -14918,7 +15514,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14932,8 +15528,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14942,12 +15538,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14956,6 +15553,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14969,7 +15567,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14986,8 +15584,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14996,12 +15594,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15010,6 +15609,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15018,7 +15618,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15027,20 +15627,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15049,7 +15651,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15058,20 +15660,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15081,7 +15685,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15112,8 +15716,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15122,6 +15726,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15150,7 +15755,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15165,7 +15770,7 @@
     <measure implicit="no" number="78">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -15227,8 +15832,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15237,6 +15842,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15266,7 +15872,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15276,11 +15882,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -15291,7 +15898,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15304,7 +15911,21 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15317,24 +15938,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15346,7 +15955,7 @@
     <measure implicit="no" number="79">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15359,11 +15968,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15372,7 +15982,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15385,7 +15995,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15420,8 +16030,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15430,6 +16040,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15441,7 +16052,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15462,7 +16073,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15475,8 +16086,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15485,6 +16096,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15506,7 +16118,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15541,8 +16153,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15551,6 +16163,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15562,7 +16175,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15600,11 +16213,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15613,7 +16227,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15629,7 +16243,21 @@
     <measure implicit="no" number="81">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15642,7 +16270,21 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15655,37 +16297,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15694,7 +16311,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15720,8 +16337,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15730,12 +16347,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15744,6 +16362,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15782,7 +16401,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15806,8 +16425,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15816,6 +16435,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15841,7 +16461,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15862,11 +16482,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15875,7 +16496,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15889,7 +16510,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15920,8 +16541,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15930,6 +16551,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15958,7 +16580,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15973,7 +16595,7 @@
     <measure implicit="no" number="83">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -16035,8 +16657,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16045,6 +16667,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -16074,7 +16697,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16087,11 +16710,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16100,7 +16724,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16109,11 +16733,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16123,7 +16748,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16136,11 +16761,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16152,7 +16778,7 @@
     <measure implicit="no" number="84">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16166,7 +16792,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16179,7 +16805,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16193,7 +16819,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16214,7 +16840,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16227,8 +16853,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16237,6 +16863,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16258,7 +16885,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16293,8 +16920,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16303,6 +16930,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -16314,7 +16942,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16375,7 +17003,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16384,11 +17012,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16400,11 +17029,12 @@
     <measure implicit="no" number="86">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16413,7 +17043,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16422,8 +17052,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16431,11 +17061,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16444,8 +17075,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16454,6 +17085,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -16470,8 +17102,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16480,12 +17112,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16511,11 +17144,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16524,7 +17158,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16533,17 +17177,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16555,11 +17190,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16568,16 +17204,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16598,8 +17235,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16608,6 +17245,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16633,7 +17271,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16650,8 +17288,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16660,6 +17298,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16668,28 +17307,30 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16702,8 +17343,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16712,6 +17353,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16728,8 +17370,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16738,6 +17380,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16751,8 +17394,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16761,6 +17404,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -16768,7 +17412,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16786,8 +17430,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16796,6 +17440,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16812,8 +17457,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16822,6 +17467,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16835,8 +17481,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16845,6 +17491,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -16852,7 +17499,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16890,8 +17537,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16900,6 +17547,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16916,7 +17564,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16943,8 +17591,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16953,11 +17601,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16966,6 +17615,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -16983,16 +17633,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17005,11 +17656,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17018,8 +17670,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17028,6 +17680,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -17045,7 +17698,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17063,8 +17716,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17073,6 +17726,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -17090,8 +17744,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17100,11 +17754,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17113,6 +17768,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -17123,11 +17779,12 @@
     <measure implicit="no" number="89">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17137,11 +17794,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />

--- a/public/transcription-samples/ado-mirror/adtof-plus-drums/ADP8962377fd12c_drum_transcription.musicxml
+++ b/public/transcription-samples/ado-mirror/adtof-plus-drums/ADP8962377fd12c_drum_transcription.musicxml
@@ -5,8 +5,11 @@
   <identification>
     <creator type="composer">Music21</creator>
     <encoding>
-      <encoding-date>2026-07-03</encoding-date>
-      <software>music21 v.9.9.2</software>
+      <encoding-date>2026-07-05</encoding-date>
+      <software>music21 v.10.5.0</software>
+      <supports element="beam" type="yes" />
+      <supports element="stem" type="yes" />
+      <supports element="accidental" type="yes" />
     </encoding>
   </identification>
   <defaults>
@@ -16,21 +19,21 @@
     </scaling>
   </defaults>
   <part-list>
-    <score-part id="Pe913dc83dd59af13dbe53275cc0b5a16">
+    <score-part id="Pc7ef48c06efd16242abecee8c1ce5860">
       <part-name>Percussion</part-name>
       <part-abbreviation>Perc</part-abbreviation>
-      <score-instrument id="I03faeddc1311ecc20b342f62e6508e85">
+      <score-instrument id="Icfd083121bc9a54653f344c3a35a471c">
         <instrument-name>Percussion</instrument-name>
         <instrument-abbreviation>Perc</instrument-abbreviation>
       </score-instrument>
-      <midi-instrument id="I03faeddc1311ecc20b342f62e6508e85">
+      <midi-instrument id="Icfd083121bc9a54653f344c3a35a471c">
         <midi-channel>10</midi-channel>
         <midi-program>1</midi-program>
       </midi-instrument>
     </score-part>
   </part-list>
   <!--=========================== Part 1 ===========================-->
-  <part id="Pe913dc83dd59af13dbe53275cc0b5a16">
+  <part id="Pc7ef48c06efd16242abecee8c1ce5860">
     <!--========================= Measure 1 ==========================-->
     <measure implicit="no" number="1">
       <attributes>
@@ -40,8 +43,7 @@
           <beat-type>4</beat-type>
         </time>
         <clef>
-          <sign>G</sign>
-          <line>2</line>
+          <sign>percussion</sign>
         </clef>
       </attributes>
       <direction>
@@ -90,7 +92,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -99,11 +101,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -115,11 +118,12 @@
     <measure implicit="no" number="6">
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -128,16 +132,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -150,8 +155,8 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -160,6 +165,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -176,8 +182,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -186,12 +192,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -217,11 +224,12 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -230,16 +238,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -252,11 +261,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -265,16 +275,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -295,8 +306,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -305,6 +316,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -330,7 +342,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -347,8 +359,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -357,6 +369,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -365,28 +378,30 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -399,8 +414,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -409,6 +424,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -425,8 +441,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -435,6 +451,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -448,8 +465,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -458,6 +475,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -465,7 +483,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -483,8 +501,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -493,6 +511,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -509,8 +528,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -519,6 +538,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -532,8 +552,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -542,6 +562,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -549,7 +570,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -587,8 +608,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -597,6 +618,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -613,7 +635,7 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -639,8 +661,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -649,6 +671,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -666,16 +689,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -688,20 +712,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -710,8 +736,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -720,6 +746,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -737,7 +764,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -755,8 +782,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -765,6 +792,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -782,8 +810,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -792,11 +820,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -805,6 +834,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -813,8 +843,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -823,13 +853,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 9 ==========================-->
     <measure implicit="no" number="9">
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -842,11 +873,12 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -855,7 +887,7 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -890,8 +922,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -900,22 +932,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -928,16 +962,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -950,42 +1009,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -997,7 +1036,17 @@
     <measure implicit="no" number="10">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1006,20 +1055,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1028,8 +1069,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1038,6 +1079,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1059,7 +1101,7 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1097,11 +1139,12 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1110,8 +1153,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1120,6 +1163,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1136,7 +1180,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1159,8 +1203,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1169,6 +1213,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -1176,8 +1221,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1186,6 +1231,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -1194,16 +1240,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1219,8 +1266,8 @@
     <measure implicit="no" number="11">
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1229,6 +1276,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -1245,8 +1293,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1255,12 +1303,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1286,7 +1335,21 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="126.67">
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1299,21 +1362,8 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="126.67">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1322,6 +1372,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -1338,8 +1389,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1348,12 +1399,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1379,20 +1431,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -1401,16 +1455,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1426,20 +1481,22 @@
     <measure implicit="no" number="12">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1448,16 +1505,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1470,11 +1528,12 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1483,7 +1542,7 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1496,8 +1555,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1506,6 +1565,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1531,8 +1591,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1541,6 +1601,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -1548,7 +1609,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1566,8 +1627,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1576,6 +1637,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1592,8 +1654,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1602,6 +1664,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -1615,8 +1678,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1625,6 +1688,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -1632,7 +1696,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1653,41 +1717,45 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1696,7 +1764,7 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1722,8 +1790,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1732,6 +1800,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -1749,7 +1818,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1758,11 +1827,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1771,18 +1841,19 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1791,6 +1862,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -1809,7 +1881,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1827,8 +1899,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1837,6 +1909,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1868,16 +1941,17 @@
     <measure implicit="no" number="14">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1890,20 +1964,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1912,8 +1988,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1922,6 +1998,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -1938,7 +2015,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1952,8 +2029,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1962,6 +2039,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1975,8 +2053,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1985,6 +2063,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -1996,8 +2075,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2006,6 +2085,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -2022,7 +2102,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2045,8 +2125,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2055,22 +2135,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2083,11 +2165,12 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2099,16 +2182,17 @@
     <measure implicit="no" number="15">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2121,11 +2205,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2134,16 +2219,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2156,8 +2242,8 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2166,6 +2252,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -2187,7 +2274,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2213,8 +2300,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2223,6 +2310,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2239,28 +2327,30 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2273,12 +2363,13 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="start" />
         </notations>
@@ -2288,8 +2379,8 @@
     <measure implicit="no" number="16">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -2299,6 +2390,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="stop" />
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -2350,8 +2442,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2360,6 +2452,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -2367,7 +2460,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2402,8 +2495,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2412,6 +2505,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -2419,8 +2513,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2429,6 +2523,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2437,8 +2532,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2447,6 +2542,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -2463,7 +2559,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2477,8 +2573,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2487,6 +2583,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2503,11 +2600,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2516,7 +2614,7 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2529,11 +2627,12 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2542,16 +2641,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2567,11 +2667,12 @@
     <measure implicit="no" number="17">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2580,16 +2681,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2602,8 +2704,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2612,6 +2714,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -2629,8 +2732,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2639,11 +2742,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2652,13 +2756,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2667,6 +2772,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2683,7 +2789,7 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2696,11 +2802,12 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2709,7 +2816,7 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2740,8 +2847,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2750,6 +2857,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -2766,8 +2874,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2776,6 +2884,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -2784,7 +2893,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2805,16 +2914,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2827,42 +2961,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2871,11 +2985,12 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2897,7 +3012,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2923,8 +3038,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2933,6 +3048,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2946,8 +3062,8 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2956,6 +3072,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -2967,16 +3084,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2989,27 +3107,29 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 20 =========================-->
     <measure implicit="no" number="20">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3022,16 +3142,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3044,11 +3165,12 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3057,16 +3179,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3079,11 +3202,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3092,7 +3216,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3108,28 +3232,30 @@
     <measure implicit="no" number="21">
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3142,8 +3268,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3152,6 +3278,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -3168,8 +3295,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3178,12 +3305,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3209,8 +3337,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3219,6 +3347,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -3236,8 +3365,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3246,11 +3375,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3259,12 +3389,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3290,8 +3421,8 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3300,6 +3431,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3325,7 +3457,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3349,28 +3481,30 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3383,11 +3517,12 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3396,16 +3531,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3418,20 +3554,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3440,26 +3578,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3491,8 +3631,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3501,6 +3641,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3529,7 +3670,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3538,18 +3679,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 23 =========================-->
     <measure implicit="no" number="23">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -3575,8 +3717,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -3585,6 +3727,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3623,8 +3766,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3633,6 +3776,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -3640,8 +3784,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3650,6 +3794,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -3668,7 +3813,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3686,20 +3831,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3708,8 +3855,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3718,6 +3865,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3735,7 +3883,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3753,8 +3901,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3763,6 +3911,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3779,8 +3928,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3789,6 +3938,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3805,7 +3955,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3814,20 +3974,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3836,11 +3988,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3852,16 +4005,17 @@
     <measure implicit="no" number="24">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3874,11 +4028,12 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3887,8 +4042,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3897,6 +4052,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3913,7 +4069,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3936,8 +4092,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3946,14 +4102,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3962,6 +4119,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3978,7 +4136,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4001,8 +4159,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4011,22 +4169,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4039,11 +4199,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 25 =========================-->
@@ -4055,7 +4216,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4068,16 +4229,17 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4086,6 +4248,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4102,7 +4265,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4125,8 +4288,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4135,6 +4298,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4142,8 +4306,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4152,6 +4316,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4160,38 +4325,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4204,16 +4348,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4229,11 +4398,12 @@
     <measure implicit="no" number="26">
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4242,7 +4412,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4273,8 +4443,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4283,6 +4453,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4299,7 +4470,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4325,11 +4496,12 @@
       </note>
       <note dynamics="106.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4338,16 +4510,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4360,27 +4533,29 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4389,6 +4564,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -4406,8 +4582,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4416,6 +4592,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4429,7 +4606,7 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4453,8 +4630,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4463,6 +4640,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4488,7 +4666,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4505,8 +4683,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4515,6 +4693,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4523,28 +4702,30 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4557,8 +4738,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4567,6 +4748,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4583,8 +4765,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4593,6 +4775,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4606,8 +4789,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4616,6 +4799,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4623,7 +4807,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4641,8 +4825,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4651,6 +4835,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4667,8 +4852,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4677,6 +4862,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4690,8 +4876,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4700,6 +4886,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4740,7 +4927,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4751,7 +4938,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4759,11 +4946,12 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -4774,7 +4962,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4800,8 +4988,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4810,6 +4998,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4823,8 +5012,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4833,6 +5022,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4840,8 +5030,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4850,23 +5040,25 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 32 =========================-->
     <measure implicit="no" number="32">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4878,7 +5070,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4887,20 +5088,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4909,11 +5102,12 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4922,16 +5116,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4944,8 +5139,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4954,6 +5149,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4979,8 +5175,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4989,11 +5185,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5006,8 +5203,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5016,6 +5213,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5023,8 +5221,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5033,6 +5231,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5058,8 +5257,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5068,6 +5267,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5075,7 +5275,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5113,8 +5313,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5123,6 +5323,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5136,8 +5337,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5146,6 +5347,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5153,7 +5355,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5171,8 +5373,8 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5181,6 +5383,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5209,7 +5412,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5218,11 +5421,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5231,28 +5435,30 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5268,16 +5474,17 @@
     <measure implicit="no" number="34">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5290,20 +5497,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5312,8 +5521,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5322,6 +5531,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5338,7 +5548,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5361,8 +5571,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5371,6 +5581,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5382,7 +5593,7 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5417,8 +5628,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5427,22 +5638,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5455,11 +5668,12 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5471,8 +5685,8 @@
     <measure implicit="no" number="35">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5481,6 +5695,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5497,7 +5712,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5520,8 +5735,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5530,6 +5745,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5537,8 +5753,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5547,11 +5763,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5560,6 +5777,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5577,8 +5795,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5587,10 +5805,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5614,8 +5833,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5624,6 +5843,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5635,7 +5855,7 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5673,28 +5893,30 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5707,12 +5929,13 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="start" />
         </notations>
@@ -5722,8 +5945,8 @@
     <measure implicit="no" number="36">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -5733,6 +5956,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="stop" />
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5784,8 +6008,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5794,6 +6018,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5801,7 +6026,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5836,8 +6061,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5846,6 +6071,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5853,8 +6079,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5863,6 +6089,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5871,8 +6098,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5881,6 +6108,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5942,7 +6170,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5951,11 +6179,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5964,11 +6193,12 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5977,8 +6207,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5987,6 +6217,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6004,7 +6235,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6022,8 +6253,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6032,6 +6263,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -6048,8 +6280,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6058,6 +6290,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -6066,7 +6299,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6088,8 +6321,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6098,6 +6331,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6115,7 +6349,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6133,8 +6367,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6143,6 +6377,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6171,16 +6406,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6193,7 +6429,21 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="130.00">
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6206,41 +6456,30 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="130.00">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6256,16 +6495,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6278,20 +6518,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6300,8 +6542,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6310,6 +6552,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6326,7 +6569,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6349,8 +6592,8 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6359,6 +6602,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6370,7 +6614,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6383,19 +6627,20 @@
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 40 =========================-->
     <measure implicit="no" number="40">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6404,6 +6649,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6420,7 +6666,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6443,8 +6689,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6453,6 +6699,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6460,8 +6707,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6470,6 +6717,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6478,8 +6726,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6488,6 +6736,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6504,7 +6753,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6527,8 +6776,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6537,12 +6786,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6551,11 +6801,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6564,6 +6815,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -6572,8 +6824,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6582,10 +6834,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6624,11 +6877,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6637,7 +6891,7 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6653,28 +6907,30 @@
     <measure implicit="no" number="41">
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6687,8 +6943,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6697,6 +6953,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6714,8 +6971,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6724,6 +6981,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6732,8 +6990,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6742,6 +7000,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6758,7 +7017,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6781,8 +7040,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6791,6 +7050,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -6799,8 +7059,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6809,11 +7069,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6822,6 +7083,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -6839,7 +7101,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6853,8 +7115,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6863,6 +7125,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6876,8 +7139,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6886,6 +7149,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6914,8 +7178,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6924,6 +7188,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6931,7 +7196,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6952,28 +7217,30 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6986,28 +7253,30 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7020,8 +7289,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7030,6 +7299,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7055,8 +7325,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7065,11 +7335,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7095,8 +7366,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7105,6 +7376,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7130,7 +7402,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -7149,7 +7421,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -7175,7 +7447,7 @@
     <measure implicit="no" number="43">
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -7237,8 +7509,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7247,6 +7519,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -7254,8 +7527,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7264,6 +7537,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -7282,7 +7556,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7300,20 +7574,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7322,8 +7598,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7332,6 +7608,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7349,7 +7626,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7367,8 +7644,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7377,6 +7654,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7393,8 +7671,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7403,6 +7681,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7419,16 +7698,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7441,11 +7721,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7457,7 +7738,7 @@
     <measure implicit="no" number="44">
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7470,11 +7751,12 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7483,16 +7765,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7505,20 +7788,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7527,16 +7812,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7549,41 +7835,45 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7592,7 +7882,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7605,11 +7895,12 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 45 =========================-->
@@ -7621,7 +7912,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7634,17 +7925,111 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+        <notations>
+          <tuplet bracket="yes" number="1" placement="above" type="start">
+            <tuplet-actual>
+              <tuplet-number>3</tuplet-number>
+              <tuplet-type>eighth</tuplet-type>
+            </tuplet-actual>
+            <tuplet-normal>
+              <tuplet-number>2</tuplet-number>
+              <tuplet-type>eighth</tuplet-type>
+            </tuplet-normal>
+          </tuplet>
+        </notations>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <rest />
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+        <notations>
+          <tuplet number="1" type="stop" />
+        </notations>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
         <duration>3360</duration>
         <type>eighth</type>
         <time-modification>
@@ -7666,49 +8051,8 @@
         </notations>
       </note>
       <note>
-        <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <rest />
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <notations>
-          <tuplet number="1" type="stop" />
-        </notations>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7722,8 +8066,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7732,55 +8076,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <rest />
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <notations>
-          <tuplet bracket="yes" number="1" placement="above" type="start">
-            <tuplet-actual>
-              <tuplet-number>3</tuplet-number>
-              <tuplet-type>eighth</tuplet-type>
-            </tuplet-actual>
-            <tuplet-normal>
-              <tuplet-number>2</tuplet-number>
-              <tuplet-type>eighth</tuplet-type>
-            </tuplet-normal>
-          </tuplet>
-        </notations>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7797,18 +8093,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7816,18 +8113,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7843,11 +8141,12 @@
     <measure implicit="no" number="46">
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7856,16 +8155,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7878,8 +8178,8 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7888,6 +8188,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -7904,8 +8205,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7914,12 +8215,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7945,11 +8247,12 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7958,16 +8261,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7980,11 +8284,12 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7993,16 +8298,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8023,8 +8329,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8033,6 +8339,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8058,7 +8365,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8079,28 +8386,30 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8113,8 +8422,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8123,6 +8432,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8148,8 +8458,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8158,6 +8468,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -8165,7 +8476,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8183,8 +8494,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8193,6 +8504,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8218,8 +8530,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8228,6 +8540,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -8235,7 +8548,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8273,8 +8586,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8283,6 +8596,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8299,7 +8613,7 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8325,8 +8639,8 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8335,6 +8649,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -8352,16 +8667,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8374,20 +8690,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8396,8 +8714,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8406,6 +8724,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8423,7 +8742,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8441,8 +8760,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8451,6 +8770,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8468,8 +8788,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8478,11 +8798,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8491,6 +8812,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -8499,8 +8821,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8509,13 +8831,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 49 =========================-->
     <measure implicit="no" number="49">
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8528,11 +8851,12 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8541,7 +8865,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8567,8 +8891,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8577,6 +8901,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8590,8 +8915,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8600,22 +8925,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8628,16 +8955,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8650,42 +9002,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8697,16 +9029,17 @@
     <measure implicit="no" number="50">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8719,8 +9052,8 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8729,6 +9062,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -8750,7 +9084,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8788,11 +9122,12 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8801,16 +9136,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8823,28 +9159,30 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8860,8 +9198,8 @@
     <measure implicit="no" number="51">
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8870,6 +9208,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8886,8 +9225,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8896,12 +9235,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8927,11 +9267,12 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8940,7 +9281,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8953,8 +9294,8 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8963,6 +9304,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8979,8 +9321,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8989,12 +9331,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9020,11 +9363,12 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9033,16 +9377,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9058,20 +9403,22 @@
     <measure implicit="no" number="52">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9080,16 +9427,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9102,11 +9450,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9115,7 +9464,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9128,8 +9477,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9138,6 +9487,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9163,8 +9513,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9173,11 +9523,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9190,8 +9541,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9200,6 +9551,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -9207,8 +9559,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9217,6 +9569,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9242,8 +9595,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9252,6 +9605,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -9259,7 +9613,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9280,41 +9634,45 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9323,7 +9681,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9349,8 +9707,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9359,6 +9717,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -9376,7 +9735,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9385,11 +9744,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9398,18 +9758,19 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9418,6 +9779,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -9436,7 +9798,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9454,8 +9816,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9464,6 +9826,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9495,16 +9858,17 @@
     <measure implicit="no" number="54">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9517,20 +9881,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9539,8 +9905,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9549,6 +9915,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9565,7 +9932,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9579,8 +9946,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9589,6 +9956,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9602,8 +9970,8 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9612,6 +9980,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -9623,8 +9992,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9633,6 +10002,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9649,7 +10019,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9672,8 +10042,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9682,22 +10052,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9710,20 +10082,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9735,16 +10109,17 @@
     <measure implicit="no" number="55">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9757,11 +10132,12 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9770,16 +10146,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9792,8 +10169,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9802,6 +10179,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9823,7 +10201,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9861,28 +10239,30 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9895,28 +10275,30 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 56 =========================-->
     <measure implicit="no" number="56">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -9925,6 +10307,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9941,8 +10324,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -9951,6 +10334,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9989,8 +10373,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9999,6 +10383,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10006,7 +10391,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10041,8 +10426,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10051,6 +10436,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10058,8 +10444,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10068,6 +10454,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10076,8 +10463,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10086,6 +10473,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10102,7 +10490,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10128,11 +10516,12 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10141,8 +10530,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10150,7 +10539,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10163,11 +10552,12 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10176,16 +10566,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10201,16 +10592,41 @@
     <measure implicit="no" number="57">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10223,30 +10639,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10255,6 +10649,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -10272,8 +10667,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10282,11 +10677,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10295,13 +10691,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10310,6 +10707,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10326,7 +10724,7 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10339,11 +10737,12 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10352,7 +10751,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10379,8 +10778,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10393,8 +10792,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10411,8 +10810,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10421,6 +10820,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -10437,8 +10837,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10447,6 +10847,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -10455,7 +10856,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10476,16 +10877,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10498,42 +10924,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10542,8 +10948,8 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10552,6 +10958,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10622,8 +11029,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10632,6 +11039,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10639,7 +11047,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10675,11 +11083,12 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10688,7 +11097,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10697,8 +11106,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10713,28 +11122,30 @@
     <measure implicit="no" number="61">
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10747,8 +11158,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10757,6 +11168,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10774,8 +11186,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10784,6 +11196,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -10792,8 +11205,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10802,6 +11215,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10818,7 +11232,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10841,8 +11255,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10851,6 +11265,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -10858,8 +11273,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10868,6 +11283,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -10885,7 +11301,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10908,8 +11324,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10918,6 +11334,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10946,7 +11363,7 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10970,28 +11387,30 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11004,11 +11423,12 @@
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11017,16 +11437,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11039,8 +11460,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11049,6 +11470,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11065,8 +11487,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11075,6 +11497,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11088,8 +11511,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11098,6 +11521,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -11105,7 +11529,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11140,8 +11564,8 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11150,6 +11574,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11166,7 +11591,7 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11181,7 +11606,7 @@
     <measure implicit="no" number="63">
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -11243,8 +11668,8 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11253,6 +11678,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -11260,8 +11686,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11270,6 +11696,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -11288,7 +11715,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11306,20 +11733,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11328,8 +11757,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11338,6 +11767,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11355,7 +11785,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11373,8 +11803,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11383,6 +11813,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -11400,8 +11831,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11410,11 +11841,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11423,6 +11855,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -11431,8 +11864,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11441,10 +11874,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11457,11 +11891,12 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11473,7 +11908,7 @@
     <measure implicit="no" number="64">
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11486,7 +11921,31 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11499,16 +11958,41 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11521,20 +12005,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11543,7 +12029,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11552,64 +12048,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11618,11 +12062,12 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 65 =========================-->
@@ -11634,7 +12079,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11643,11 +12088,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11656,16 +12102,17 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11674,6 +12121,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11690,7 +12138,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11713,8 +12161,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11723,6 +12171,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -11730,8 +12179,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11740,6 +12189,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11748,16 +12198,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11770,28 +12221,30 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11807,11 +12260,12 @@
     <measure implicit="no" number="66">
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11820,7 +12274,7 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11833,8 +12287,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11843,6 +12297,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -11859,8 +12314,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11869,12 +12324,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11900,7 +12356,31 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11913,20 +12393,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11935,38 +12417,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11987,8 +12448,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11997,6 +12458,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12022,7 +12484,7 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12043,28 +12505,30 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12077,11 +12541,12 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12090,7 +12555,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12103,45 +12568,49 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12158,7 +12627,7 @@
     <measure implicit="no" number="68">
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -12220,8 +12689,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12230,6 +12699,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -12258,8 +12728,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12268,12 +12738,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12286,8 +12757,8 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12296,6 +12767,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -12326,16 +12798,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12348,20 +12821,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12370,8 +12845,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12380,6 +12855,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12397,7 +12873,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12415,8 +12891,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12425,6 +12901,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12441,8 +12918,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12451,6 +12928,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12470,27 +12948,29 @@
     <measure implicit="no" number="69">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12498,19 +12978,20 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12522,8 +13003,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12548,7 +13029,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12562,8 +13043,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12572,6 +13053,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12585,8 +13067,8 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12595,14 +13077,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12611,6 +13094,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12627,7 +13111,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12650,8 +13134,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12660,22 +13144,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12688,27 +13174,29 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 70 =========================-->
     <measure implicit="no" number="70">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12721,8 +13209,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12731,6 +13219,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12752,8 +13241,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12762,6 +13251,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12778,7 +13268,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12804,11 +13294,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12817,8 +13308,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12827,6 +13318,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12843,7 +13335,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12866,8 +13358,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12876,6 +13368,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -12883,8 +13376,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12893,6 +13386,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12901,16 +13395,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12923,28 +13418,30 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 71 =========================-->
     <measure implicit="no" number="71">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -12953,6 +13450,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12969,8 +13467,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -12979,6 +13477,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13017,8 +13516,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13027,6 +13526,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -13034,7 +13534,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13070,11 +13570,12 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13083,7 +13584,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13096,8 +13597,8 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13106,6 +13607,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -13122,8 +13624,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13132,12 +13634,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13163,20 +13666,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13185,16 +13690,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13210,8 +13716,8 @@
     <measure implicit="no" number="72">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13220,6 +13726,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -13237,8 +13744,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13247,11 +13754,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13260,13 +13768,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13275,10 +13784,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13300,11 +13810,12 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13313,7 +13824,7 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13326,8 +13837,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13336,6 +13847,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13361,8 +13873,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13371,11 +13883,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13388,8 +13901,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13398,6 +13911,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -13405,8 +13919,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13415,6 +13929,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13440,8 +13955,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13450,6 +13965,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -13457,7 +13973,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13478,20 +13994,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13500,8 +14018,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13510,6 +14028,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13527,7 +14046,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13541,8 +14060,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13551,6 +14070,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13559,8 +14079,8 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13569,6 +14089,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13597,7 +14118,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13606,11 +14127,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13619,28 +14141,30 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13653,11 +14177,12 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13669,16 +14194,17 @@
     <measure implicit="no" number="74">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13691,11 +14217,12 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13704,8 +14231,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13714,6 +14241,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13730,7 +14258,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13753,8 +14281,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13763,6 +14291,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -13774,7 +14303,7 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13809,8 +14338,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13819,22 +14348,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13847,19 +14378,20 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 75 =========================-->
     <measure implicit="no" number="75">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13868,6 +14400,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13884,7 +14417,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13907,8 +14440,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13917,6 +14450,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -13924,8 +14458,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13934,6 +14468,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13942,16 +14477,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13964,8 +14500,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13974,6 +14510,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13995,7 +14532,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14033,28 +14570,30 @@
       </note>
       <note dynamics="103.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14067,12 +14606,13 @@
       </note>
       <note dynamics="105.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="start" />
         </notations>
@@ -14082,8 +14622,8 @@
     <measure implicit="no" number="76">
       <note dynamics="105.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -14093,6 +14633,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="stop" />
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -14144,8 +14685,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14154,6 +14695,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14161,7 +14703,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14197,20 +14739,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14219,26 +14763,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14253,11 +14799,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14266,7 +14813,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14275,11 +14822,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14288,11 +14836,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14301,16 +14850,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14326,8 +14876,8 @@
     <measure implicit="no" number="77">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14336,6 +14886,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -14352,7 +14903,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14366,8 +14917,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14376,6 +14927,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14389,7 +14941,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14406,8 +14958,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14416,10 +14968,21 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14428,20 +14991,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14450,16 +15005,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14472,8 +15028,8 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14482,6 +15038,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -14507,8 +15064,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14517,11 +15074,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14547,8 +15105,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14557,6 +15115,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -14582,7 +15141,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -14601,7 +15160,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -14627,7 +15186,7 @@
     <measure implicit="no" number="78">
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -14689,8 +15248,8 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14699,6 +15258,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14728,7 +15288,7 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14738,11 +15298,12 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -14753,7 +15314,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14766,11 +15327,12 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14779,7 +15341,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14792,11 +15354,12 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14808,7 +15371,7 @@
     <measure implicit="no" number="79">
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14821,11 +15384,12 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14834,7 +15398,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14847,7 +15411,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14882,8 +15446,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14892,6 +15456,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14903,7 +15468,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14924,7 +15489,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14937,8 +15502,8 @@
       </note>
       <note dynamics="136.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14947,6 +15512,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -14968,7 +15534,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15003,8 +15569,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15013,6 +15579,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15024,7 +15591,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15062,11 +15629,12 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15075,7 +15643,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15091,11 +15659,12 @@
     <measure implicit="no" number="81">
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15104,7 +15673,7 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15117,11 +15686,12 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15130,7 +15700,7 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15143,11 +15713,12 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15156,7 +15727,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15165,11 +15736,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15178,8 +15750,8 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15188,6 +15760,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15213,8 +15786,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15223,6 +15796,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15230,7 +15804,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15251,8 +15825,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15261,6 +15835,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15286,7 +15861,7 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15307,11 +15882,12 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15320,7 +15896,7 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15334,7 +15910,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15365,8 +15941,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15375,6 +15951,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15403,7 +15980,7 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15418,7 +15995,7 @@
     <measure implicit="no" number="83">
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -15480,8 +16057,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15490,6 +16067,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15519,7 +16097,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15532,11 +16110,12 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15545,7 +16124,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15554,11 +16133,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15568,7 +16148,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15581,11 +16161,12 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15597,7 +16178,7 @@
     <measure implicit="no" number="84">
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15632,8 +16213,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15642,13 +16223,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15661,7 +16243,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15696,8 +16278,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15706,6 +16288,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15717,7 +16300,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15738,7 +16321,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15751,8 +16334,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15761,6 +16344,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15782,7 +16366,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15820,11 +16404,12 @@
       </note>
       <note dynamics="138.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15833,27 +16418,29 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15861,22 +16448,24 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15885,11 +16474,12 @@
       </note>
       <note dynamics="136.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15898,7 +16488,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15907,20 +16497,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15932,11 +16524,12 @@
     <measure implicit="no" number="86">
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15945,7 +16538,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15954,17 +16557,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15976,8 +16570,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15986,6 +16580,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -16002,8 +16597,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16012,12 +16607,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16043,20 +16639,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16065,16 +16663,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16087,11 +16686,12 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16100,16 +16700,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16130,8 +16731,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16140,6 +16741,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16165,7 +16767,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16182,8 +16784,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16200,28 +16802,30 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16234,8 +16838,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16244,6 +16848,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16260,8 +16865,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16270,6 +16875,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16283,8 +16889,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16293,6 +16899,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -16300,7 +16907,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16318,8 +16925,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16328,6 +16935,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16344,8 +16952,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16354,6 +16962,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16367,8 +16976,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16377,6 +16986,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -16384,7 +16994,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16422,8 +17032,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16432,6 +17042,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16448,8 +17059,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16475,7 +17086,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16488,8 +17099,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16498,6 +17109,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -16515,16 +17127,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16537,20 +17150,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16559,8 +17174,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16569,6 +17184,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16586,7 +17202,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16604,8 +17220,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16614,6 +17230,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -16632,8 +17249,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16642,25 +17259,28 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">backward hook</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />

--- a/public/transcription-samples/cant-stop/adtof-drums/ADT867f971b230e_drum_transcription.musicxml
+++ b/public/transcription-samples/cant-stop/adtof-drums/ADT867f971b230e_drum_transcription.musicxml
@@ -5,7 +5,7 @@
   <identification>
     <creator type="composer">Music21</creator>
     <encoding>
-      <encoding-date>2026-07-03</encoding-date>
+      <encoding-date>2026-07-05</encoding-date>
       <software>music21 v.10.5.0</software>
       <supports element="beam" type="yes" />
       <supports element="stem" type="yes" />
@@ -19,21 +19,21 @@
     </scaling>
   </defaults>
   <part-list>
-    <score-part id="P25916a87c096a6d187ac63436d89ca72">
+    <score-part id="P089eb698b469e49e99b821d6763cf716">
       <part-name>Percussion</part-name>
       <part-abbreviation>Perc</part-abbreviation>
-      <score-instrument id="I80d5361faa6e48ed96f5984e35062c06">
+      <score-instrument id="Ib2766f54794fc264d9046e0ebeee3457">
         <instrument-name>Percussion</instrument-name>
         <instrument-abbreviation>Perc</instrument-abbreviation>
       </score-instrument>
-      <midi-instrument id="I80d5361faa6e48ed96f5984e35062c06">
+      <midi-instrument id="Ib2766f54794fc264d9046e0ebeee3457">
         <midi-channel>10</midi-channel>
         <midi-program>2</midi-program>
       </midi-instrument>
     </score-part>
   </part-list>
   <!--=========================== Part 1 ===========================-->
-  <part id="P25916a87c096a6d187ac63436d89ca72">
+  <part id="P089eb698b469e49e99b821d6763cf716">
     <!--========================= Measure 1 ==========================-->
     <measure implicit="no" number="1">
       <attributes>
@@ -43,8 +43,7 @@
           <beat-type>4</beat-type>
         </time>
         <clef>
-          <sign>G</sign>
-          <line>2</line>
+          <sign>percussion</sign>
         </clef>
       </attributes>
       <direction>
@@ -80,8 +79,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -99,8 +98,8 @@
     <measure implicit="no" number="2">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -125,8 +124,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -139,8 +138,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -157,8 +156,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -170,8 +169,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -196,8 +195,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -210,8 +209,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -228,8 +227,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -241,8 +240,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -268,8 +267,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -281,8 +280,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -296,8 +295,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -322,8 +321,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -331,16 +330,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -366,8 +365,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -379,8 +378,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -406,8 +405,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -415,8 +414,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -426,8 +425,8 @@
     <measure implicit="no" number="3">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -452,8 +451,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -467,8 +466,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -493,8 +492,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -502,16 +501,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -537,8 +536,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -550,8 +549,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -577,8 +576,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -586,16 +585,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -603,8 +602,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -616,8 +615,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -627,16 +626,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -646,16 +645,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -667,8 +666,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -677,8 +676,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -690,8 +689,8 @@
     <measure implicit="no" number="4">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -699,8 +698,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -712,8 +711,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -723,16 +722,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -741,8 +740,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -754,8 +753,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -765,16 +764,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -784,16 +783,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -801,8 +800,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -814,8 +813,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -825,16 +824,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -844,16 +843,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -861,8 +860,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -874,8 +873,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -885,16 +884,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -904,8 +903,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -920,8 +919,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -930,8 +929,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -941,16 +940,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -964,8 +963,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -974,8 +973,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -985,16 +984,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1004,8 +1003,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1017,8 +1016,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1028,16 +1027,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1047,16 +1046,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1066,8 +1065,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1079,8 +1078,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1090,16 +1089,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1109,16 +1108,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1128,8 +1127,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1144,8 +1143,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1154,8 +1153,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1164,8 +1163,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1179,8 +1178,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1189,8 +1188,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1199,8 +1198,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1210,8 +1209,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1223,8 +1222,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1233,8 +1232,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1243,8 +1242,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1258,8 +1257,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1268,8 +1267,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1278,8 +1277,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1296,8 +1295,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1306,8 +1305,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1321,8 +1320,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1331,8 +1330,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1342,16 +1341,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1365,8 +1364,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1376,16 +1375,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1394,8 +1393,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1405,8 +1404,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1418,8 +1417,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1428,8 +1427,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1438,8 +1437,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1449,16 +1448,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1468,8 +1467,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1484,8 +1483,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1495,16 +1494,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1514,8 +1513,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1527,8 +1526,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1538,16 +1537,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1557,16 +1556,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1576,8 +1575,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1589,8 +1588,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1600,16 +1599,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1618,8 +1617,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1629,8 +1628,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1642,8 +1641,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1652,8 +1651,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1662,8 +1661,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1680,8 +1679,8 @@
     <measure implicit="no" number="9">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1690,8 +1689,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1701,16 +1700,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1720,8 +1719,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1733,8 +1732,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1744,16 +1743,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1779,8 +1778,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1802,8 +1801,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1818,8 +1817,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1828,8 +1827,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1855,8 +1854,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1878,8 +1877,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1895,8 +1894,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1908,8 +1907,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1919,16 +1918,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1954,8 +1953,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1977,8 +1976,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1994,8 +1993,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2010,8 +2009,8 @@
     <measure implicit="no" number="10">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2037,8 +2036,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2050,8 +2049,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2064,8 +2063,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2082,8 +2081,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2095,8 +2094,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2122,8 +2121,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2135,8 +2134,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2150,8 +2149,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2163,8 +2162,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2181,8 +2180,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2194,8 +2193,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2221,8 +2220,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2234,8 +2233,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2249,8 +2248,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2262,8 +2261,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2280,8 +2279,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2293,8 +2292,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2320,8 +2319,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2333,8 +2332,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2348,8 +2347,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2361,8 +2360,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2379,8 +2378,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2395,8 +2394,8 @@
     <measure implicit="no" number="11">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2422,8 +2421,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2435,8 +2434,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2449,8 +2448,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2466,8 +2465,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2493,8 +2492,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2506,8 +2505,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2520,8 +2519,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2538,8 +2537,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2551,8 +2550,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2578,8 +2577,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2591,8 +2590,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2606,8 +2605,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2632,8 +2631,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2641,16 +2640,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2675,8 +2674,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2690,8 +2689,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2716,8 +2715,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2727,8 +2726,8 @@
     <measure implicit="no" number="12">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2754,8 +2753,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2767,8 +2766,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2782,8 +2781,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2808,8 +2807,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2817,16 +2816,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2852,8 +2851,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2865,8 +2864,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2880,8 +2879,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2906,8 +2905,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2915,16 +2914,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2950,8 +2949,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2963,8 +2962,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2978,8 +2977,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3001,7 +3000,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3018,8 +3017,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3032,8 +3031,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3126,8 +3125,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3143,8 +3142,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3159,7 +3158,7 @@
     <measure implicit="no" number="18">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3185,8 +3184,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3195,6 +3194,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3208,7 +3208,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3225,8 +3225,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3235,6 +3235,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3243,8 +3244,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3252,11 +3253,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3265,18 +3267,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3285,11 +3288,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -3300,8 +3304,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3310,7 +3314,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3321,11 +3325,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3337,8 +3342,8 @@
     <measure implicit="no" number="19">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3346,11 +3351,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3359,18 +3365,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3380,8 +3387,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3393,7 +3400,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3402,11 +3409,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3415,7 +3423,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3424,11 +3432,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3437,8 +3446,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3448,16 +3457,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3471,18 +3481,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3490,8 +3501,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3500,11 +3511,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -3518,8 +3530,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3528,7 +3540,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3539,11 +3551,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3552,8 +3565,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3561,8 +3574,32 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3574,7 +3611,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3583,42 +3629,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3628,7 +3644,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3637,11 +3653,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3650,8 +3667,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3659,11 +3676,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 21 =========================-->
@@ -3675,8 +3693,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3685,7 +3703,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3696,16 +3714,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3714,11 +3733,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3727,8 +3747,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3737,7 +3757,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3748,11 +3768,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3761,8 +3782,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3770,8 +3791,32 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3783,30 +3828,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3831,7 +3854,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3845,8 +3868,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3855,6 +3878,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3896,7 +3920,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3910,8 +3934,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3920,6 +3944,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3936,8 +3961,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3945,11 +3970,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3958,7 +3984,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3967,16 +3993,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4001,8 +4028,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4011,12 +4038,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4032,7 +4060,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4058,8 +4086,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4068,6 +4096,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4081,8 +4110,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4098,8 +4127,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4108,12 +4137,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4122,6 +4152,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 23 =========================-->
@@ -4133,18 +4164,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4154,8 +4186,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4167,7 +4199,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4193,8 +4225,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4203,6 +4235,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4216,7 +4249,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4237,8 +4270,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4246,11 +4279,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4259,7 +4293,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4270,16 +4304,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4314,8 +4349,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4324,6 +4359,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4333,8 +4369,8 @@
     <measure implicit="no" number="24">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4343,7 +4379,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4354,11 +4390,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4367,8 +4404,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4376,11 +4413,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4389,7 +4427,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4400,16 +4438,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4419,8 +4458,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4432,7 +4471,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4441,11 +4480,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4454,7 +4494,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4463,11 +4503,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4476,8 +4517,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4485,11 +4526,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4506,7 +4548,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4517,16 +4559,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4540,18 +4583,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4560,7 +4604,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4571,11 +4615,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4584,8 +4629,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4593,8 +4638,32 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4606,7 +4675,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4615,42 +4693,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4667,7 +4715,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4676,11 +4724,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4689,8 +4738,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4698,11 +4747,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4711,18 +4761,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4736,18 +4787,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4756,7 +4808,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4767,11 +4819,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4780,8 +4833,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4789,11 +4842,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4805,8 +4859,8 @@
     <measure implicit="no" number="27">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4815,6 +4869,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -4832,8 +4887,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4842,11 +4897,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4860,8 +4916,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4886,7 +4942,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4895,11 +4951,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4908,7 +4965,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4917,11 +4974,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4930,8 +4988,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4939,11 +4997,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4952,16 +5011,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4973,18 +5033,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4996,7 +5057,7 @@
     <measure implicit="no" number="28">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5005,11 +5066,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5018,8 +5080,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5027,11 +5089,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5040,8 +5103,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5050,6 +5113,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5066,7 +5130,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5080,8 +5144,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5090,6 +5154,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5103,8 +5168,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5116,7 +5181,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5134,8 +5199,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5144,11 +5209,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5173,7 +5239,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5188,8 +5254,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5198,6 +5264,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5214,8 +5281,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5255,8 +5322,8 @@
     <measure implicit="no" number="29">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5265,6 +5332,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5281,8 +5349,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5295,8 +5363,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5305,6 +5373,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -5317,7 +5386,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5326,11 +5395,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5339,8 +5409,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5365,8 +5435,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5375,6 +5445,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5388,8 +5459,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5398,6 +5469,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5409,7 +5481,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5418,11 +5490,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5434,7 +5507,7 @@
     <measure implicit="no" number="30">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5460,8 +5533,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5470,6 +5543,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5483,8 +5557,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5500,8 +5574,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5510,6 +5584,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5518,8 +5593,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5528,6 +5603,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5553,8 +5629,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5569,18 +5645,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5589,7 +5666,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5600,11 +5677,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5613,8 +5691,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5622,11 +5700,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5638,8 +5717,8 @@
     <measure implicit="no" number="31">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5648,6 +5727,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5664,8 +5744,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5679,7 +5759,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5693,8 +5773,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5703,6 +5783,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5724,7 +5805,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5733,11 +5814,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5746,8 +5828,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5757,16 +5839,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5776,19 +5859,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -5799,8 +5884,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5809,18 +5894,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">end</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5829,7 +5915,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5840,11 +5926,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 32 =========================-->
@@ -5856,8 +5943,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5865,11 +5952,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5878,8 +5966,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5888,6 +5976,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5913,8 +6002,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5930,7 +6019,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5944,8 +6033,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5954,6 +6043,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5962,7 +6052,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5971,11 +6061,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5984,8 +6075,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5993,20 +6094,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6015,11 +6108,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 33 =========================-->
@@ -6031,8 +6125,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6041,18 +6135,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6061,7 +6156,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6070,11 +6165,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6083,8 +6179,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6110,8 +6206,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6120,6 +6216,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6128,8 +6225,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6138,6 +6235,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6166,7 +6264,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6175,20 +6282,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6198,7 +6297,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6207,18 +6306,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 34 =========================-->
     <measure implicit="no" number="34">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -6244,8 +6344,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -6254,6 +6354,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6292,8 +6393,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6309,8 +6410,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6319,6 +6420,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6344,8 +6446,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6354,12 +6456,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6398,16 +6501,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6432,7 +6536,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6447,8 +6551,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6457,6 +6561,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6473,8 +6578,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6500,8 +6605,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6510,11 +6615,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6527,8 +6633,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6537,6 +6643,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -6569,7 +6676,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6583,8 +6690,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6593,6 +6700,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6609,7 +6717,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6635,8 +6743,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6645,6 +6753,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6658,8 +6767,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6675,8 +6784,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6685,11 +6794,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6714,7 +6824,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6729,8 +6839,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6739,11 +6849,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6759,8 +6870,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6769,6 +6880,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -6785,8 +6897,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6799,7 +6911,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6817,8 +6929,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6827,6 +6939,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 36 =========================-->
@@ -6838,8 +6951,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6864,8 +6977,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6874,6 +6987,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6887,8 +7001,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6903,11 +7017,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6916,7 +7031,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6925,11 +7040,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6938,7 +7054,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6947,11 +7063,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6960,8 +7077,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6987,8 +7104,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6997,11 +7114,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7010,13 +7128,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7025,6 +7144,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7044,8 +7164,8 @@
     <measure implicit="no" number="37">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7054,18 +7174,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">end</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7074,7 +7195,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7085,11 +7206,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7098,8 +7220,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7107,11 +7229,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7120,18 +7243,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7141,15 +7265,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7160,11 +7284,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7173,7 +7298,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7182,11 +7307,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7203,8 +7329,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7212,11 +7338,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7225,11 +7352,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7238,7 +7366,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7247,20 +7384,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7269,16 +7398,16 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7303,8 +7432,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7330,16 +7459,16 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7364,8 +7493,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7391,7 +7520,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7402,7 +7531,7 @@
     <measure implicit="no" number="39">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7428,8 +7557,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7438,6 +7567,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7451,8 +7581,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7461,6 +7591,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -7489,8 +7620,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7515,8 +7646,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7525,6 +7656,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7541,7 +7673,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7564,8 +7696,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7574,14 +7706,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7606,7 +7739,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7621,8 +7754,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7631,6 +7764,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7650,8 +7784,8 @@
     <measure implicit="no" number="40">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7663,11 +7797,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7676,8 +7811,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7687,15 +7822,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7706,11 +7841,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7719,7 +7855,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7728,11 +7864,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7741,8 +7878,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7754,16 +7891,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7779,18 +7917,19 @@
     <measure implicit="no" number="41">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7799,7 +7938,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7810,11 +7949,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7823,8 +7963,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7832,17 +7972,42 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7854,7 +8019,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7863,39 +8037,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
         <duration>2520</duration>
         <type>16th</type>
       </note>
-      <note>
+      <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7907,30 +8064,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7940,8 +8085,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7958,7 +8103,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7967,11 +8112,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7980,11 +8126,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7993,7 +8140,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8002,11 +8149,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8015,8 +8163,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8028,8 +8176,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8038,6 +8186,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8054,8 +8203,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8069,8 +8218,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8095,7 +8244,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8104,18 +8253,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 43 =========================-->
     <measure implicit="no" number="43">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -8141,8 +8291,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -8151,6 +8301,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8189,8 +8340,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8199,6 +8350,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -8228,7 +8380,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8236,8 +8388,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8271,7 +8423,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8288,8 +8440,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8298,6 +8450,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8323,8 +8476,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8333,12 +8486,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8354,7 +8508,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8365,16 +8519,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8409,8 +8564,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8426,8 +8581,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8442,8 +8597,8 @@
     <measure implicit="no" number="44">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8452,8 +8607,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8462,7 +8617,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8477,7 +8632,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8486,11 +8641,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8500,7 +8656,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8510,8 +8666,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8525,7 +8681,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8538,11 +8694,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8559,7 +8716,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8568,20 +8725,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8590,8 +8749,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8603,7 +8762,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8614,16 +8773,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8637,7 +8797,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8648,16 +8808,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8671,26 +8832,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8700,8 +8863,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8723,7 +8886,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8732,11 +8895,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8745,17 +8909,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8767,8 +8932,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8777,7 +8942,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8788,11 +8953,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8801,8 +8967,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8810,11 +8976,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8823,16 +8990,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8844,7 +9012,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8855,16 +9023,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8881,7 +9050,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8891,8 +9060,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8923,7 +9092,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8949,8 +9118,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8959,6 +9128,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8975,11 +9145,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8988,7 +9159,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9015,8 +9186,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9025,6 +9196,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9033,8 +9205,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9059,8 +9231,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9069,6 +9241,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9093,8 +9266,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9119,8 +9292,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9142,7 +9315,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9156,8 +9329,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9166,6 +9339,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9204,7 +9378,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9218,8 +9392,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9228,6 +9402,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9274,8 +9449,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9297,8 +9472,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9314,8 +9489,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9332,8 +9507,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9342,6 +9517,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9358,8 +9534,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9368,6 +9544,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9384,7 +9561,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9393,11 +9570,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9406,8 +9584,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9416,6 +9594,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9437,8 +9616,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9463,8 +9642,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9473,6 +9652,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9492,8 +9672,8 @@
     <measure implicit="no" number="50">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9502,6 +9682,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -9518,8 +9699,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9542,8 +9723,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9552,6 +9733,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -9563,7 +9745,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9589,8 +9771,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9599,6 +9781,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9612,8 +9795,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9630,8 +9813,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9640,11 +9823,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9669,8 +9853,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9679,12 +9863,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9700,7 +9885,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9727,8 +9912,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9737,6 +9922,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9756,7 +9942,7 @@
     <measure implicit="no" number="51">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9782,8 +9968,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9792,6 +9978,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9805,8 +9992,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9822,8 +10009,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9832,11 +10019,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9861,8 +10049,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9871,12 +10059,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9892,8 +10081,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9902,6 +10091,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -9918,8 +10108,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9932,7 +10122,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9950,8 +10140,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9960,6 +10150,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9968,8 +10159,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9977,11 +10168,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9993,18 +10185,19 @@
     <measure implicit="no" number="52">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10030,8 +10223,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10053,7 +10246,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10070,8 +10263,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10080,6 +10273,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10088,7 +10282,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10097,11 +10291,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10110,8 +10305,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10136,8 +10331,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10146,6 +10341,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10159,8 +10355,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10169,14 +10365,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10185,18 +10382,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10213,7 +10411,7 @@
     <measure implicit="no" number="53">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10222,11 +10420,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10235,8 +10434,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10244,11 +10443,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10257,18 +10457,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10278,15 +10479,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10297,11 +10498,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10310,7 +10512,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10319,11 +10521,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10332,8 +10535,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10341,11 +10544,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10354,19 +10558,20 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 54 =========================-->
     <measure implicit="no" number="54">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10378,18 +10583,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10399,15 +10605,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10416,11 +10623,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10429,8 +10637,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10438,16 +10646,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10459,18 +10668,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10479,11 +10689,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10492,8 +10703,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10502,7 +10713,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10513,11 +10724,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 55 =========================-->
@@ -10529,17 +10741,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10551,8 +10764,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10561,6 +10774,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -10577,8 +10791,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10604,16 +10818,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10638,7 +10853,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10653,8 +10868,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10663,6 +10878,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10679,8 +10895,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10705,8 +10921,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10715,6 +10931,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10728,8 +10945,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10738,6 +10955,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10745,8 +10963,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10761,7 +10979,16 @@
     <measure implicit="no" number="56">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10770,20 +10997,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10793,7 +11012,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10819,8 +11038,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10829,6 +11048,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10842,8 +11062,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10859,8 +11079,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10869,11 +11089,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10898,8 +11119,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10908,12 +11129,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10929,18 +11151,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10975,7 +11198,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10992,8 +11215,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11002,6 +11225,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 57 =========================-->
@@ -11014,8 +11238,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11024,12 +11248,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11039,8 +11264,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -11050,13 +11275,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -11069,8 +11295,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11091,7 +11317,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11101,12 +11327,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11116,8 +11343,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11126,12 +11353,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11141,8 +11369,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11152,19 +11380,20 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11184,7 +11413,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11194,12 +11423,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11223,18 +11453,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11243,7 +11474,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11254,11 +11485,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11267,8 +11499,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11276,8 +11508,32 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11289,30 +11545,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11338,7 +11572,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11352,8 +11586,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11362,6 +11596,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11370,7 +11605,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11396,8 +11631,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11406,6 +11641,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11425,8 +11661,8 @@
     <measure implicit="no" number="59">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11434,11 +11670,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11447,16 +11684,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11481,8 +11719,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11491,6 +11729,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -11508,15 +11747,15 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11542,8 +11781,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11552,6 +11791,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11565,8 +11805,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11582,8 +11822,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11592,10 +11832,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11621,8 +11862,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11631,12 +11872,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11655,7 +11897,7 @@
     <measure implicit="no" number="60">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11664,11 +11906,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11677,7 +11920,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11690,8 +11933,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11701,16 +11944,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11724,18 +11968,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11744,11 +11989,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -11759,8 +12005,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11769,7 +12015,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11780,16 +12026,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11798,8 +12045,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11809,11 +12056,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 61 =========================-->
@@ -11825,8 +12073,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11835,19 +12083,20 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11859,7 +12108,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11868,42 +12126,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11912,7 +12140,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11921,11 +12149,35 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11934,18 +12186,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11954,11 +12207,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -11967,8 +12221,8 @@
     <measure implicit="no" number="62">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11993,7 +12247,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12008,8 +12262,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12018,6 +12272,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12034,8 +12289,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12043,11 +12298,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12056,16 +12312,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12091,8 +12348,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12104,7 +12361,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12119,8 +12376,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12129,6 +12386,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12145,7 +12403,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12171,8 +12429,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12181,6 +12439,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12194,8 +12453,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12211,8 +12470,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12221,14 +12480,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 63 =========================-->
     <measure implicit="no" number="63">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12253,8 +12513,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12263,12 +12523,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12284,18 +12545,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12330,7 +12592,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12347,8 +12609,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12357,6 +12619,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12365,8 +12628,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12376,16 +12639,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12399,18 +12663,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12419,7 +12684,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12430,11 +12695,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12451,7 +12717,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12460,11 +12726,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12473,8 +12740,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12482,11 +12749,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12495,8 +12763,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12505,7 +12773,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12516,16 +12784,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12539,11 +12808,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12552,7 +12822,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12561,11 +12831,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12574,8 +12845,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12583,11 +12854,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12599,8 +12871,22 @@
     <measure implicit="no" number="65">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12612,21 +12898,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12651,7 +12924,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12666,8 +12939,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12676,6 +12949,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12692,8 +12966,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12705,8 +12979,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12715,6 +12989,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12736,8 +13011,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12746,6 +13021,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12777,7 +13053,7 @@
     <measure implicit="no" number="66">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12803,8 +13079,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12813,6 +13089,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12826,8 +13103,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12843,8 +13120,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12853,6 +13130,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12861,7 +13139,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12887,8 +13165,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12897,6 +13175,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12910,7 +13189,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12927,8 +13206,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12937,12 +13216,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12951,6 +13231,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12959,17 +13240,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12984,11 +13266,12 @@
     <measure implicit="no" number="67">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12997,11 +13280,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13010,7 +13294,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13036,8 +13320,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13046,6 +13330,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13059,8 +13344,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13076,8 +13361,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13090,8 +13375,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13100,6 +13385,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13108,18 +13394,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13129,8 +13416,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13142,7 +13429,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13151,11 +13438,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13164,7 +13452,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13173,11 +13461,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 68 =========================-->
@@ -13189,8 +13478,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13200,16 +13489,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13223,18 +13513,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13243,8 +13534,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13253,6 +13544,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -13275,7 +13567,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13301,8 +13593,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13311,6 +13603,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13327,8 +13620,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13336,11 +13629,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13349,19 +13643,20 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 69 =========================-->
     <measure implicit="no" number="69">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13386,7 +13681,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13401,8 +13696,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13411,6 +13706,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13427,8 +13723,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13437,6 +13733,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13462,8 +13759,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13479,8 +13776,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13489,6 +13786,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13514,8 +13812,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13529,8 +13827,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13539,10 +13837,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13559,18 +13858,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13579,8 +13879,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13597,8 +13897,8 @@
     <measure implicit="no" number="70">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13607,7 +13907,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13618,8 +13918,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13627,16 +13927,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13645,8 +13945,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13660,7 +13960,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13670,7 +13970,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13681,11 +13981,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13694,8 +13995,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13707,16 +14008,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13732,11 +14034,12 @@
     <measure implicit="no" number="71">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13745,7 +14048,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13754,11 +14057,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13767,8 +14071,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13776,11 +14080,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13789,7 +14094,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13798,11 +14103,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13811,7 +14117,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13838,8 +14144,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13848,6 +14154,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13856,7 +14163,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13894,7 +14201,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13905,8 +14212,8 @@
     <measure implicit="no" number="72">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13940,7 +14247,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13957,8 +14264,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13967,6 +14274,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13992,8 +14300,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14002,6 +14310,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14015,8 +14324,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14025,6 +14334,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14032,7 +14342,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14067,8 +14377,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14084,8 +14394,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14094,12 +14404,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14108,6 +14419,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14133,7 +14445,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14148,8 +14460,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14158,11 +14470,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14179,8 +14492,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14195,7 +14508,7 @@
     <measure implicit="no" number="73">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14222,8 +14535,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14232,11 +14545,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14249,8 +14563,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14259,6 +14573,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -14266,7 +14581,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14292,8 +14607,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14319,7 +14634,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14345,8 +14660,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14355,6 +14670,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14368,8 +14684,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14378,14 +14694,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14394,7 +14711,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14405,11 +14722,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14421,8 +14739,8 @@
     <measure implicit="no" number="74">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14448,8 +14766,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14458,12 +14776,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14472,11 +14791,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14490,7 +14810,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14504,8 +14824,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14514,6 +14834,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14530,8 +14851,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14543,7 +14864,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14552,11 +14873,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14565,17 +14887,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14585,8 +14908,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14600,7 +14923,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14609,11 +14932,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14622,11 +14946,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 75 =========================-->
@@ -14638,8 +14963,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14648,7 +14973,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14659,11 +14984,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14672,8 +14998,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14682,8 +15008,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14692,27 +15018,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14724,7 +15051,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14733,11 +15060,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14746,11 +15074,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14759,7 +15088,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14769,8 +15098,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
@@ -14786,8 +15115,8 @@
     <measure implicit="no" number="76">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -14848,7 +15177,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14886,8 +15215,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14896,6 +15225,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14912,7 +15242,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14947,8 +15277,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14964,8 +15294,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14974,6 +15304,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14999,7 +15330,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15013,8 +15344,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15031,8 +15362,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15044,7 +15375,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15072,8 +15403,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15082,14 +15413,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 77 =========================-->
     <measure implicit="no" number="77">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15114,8 +15446,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15124,11 +15456,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15145,8 +15478,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15171,8 +15504,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15181,12 +15514,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15195,6 +15529,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15208,7 +15543,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15225,8 +15560,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15235,6 +15570,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15243,8 +15579,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15253,6 +15589,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15278,8 +15615,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15291,7 +15628,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15308,8 +15645,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15318,6 +15655,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15344,8 +15682,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15353,11 +15691,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15409,7 +15748,34 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15423,8 +15789,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15433,33 +15799,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15473,8 +15813,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15483,13 +15823,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15499,8 +15840,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15514,7 +15855,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15540,8 +15881,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15550,6 +15891,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15563,8 +15905,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15573,6 +15915,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15587,7 +15930,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15596,11 +15939,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15609,8 +15953,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15618,20 +15962,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15640,11 +15986,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15653,7 +16000,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15662,20 +16018,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15689,7 +16037,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15698,11 +16046,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15720,7 +16069,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15738,7 +16087,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15751,11 +16100,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15764,7 +16114,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15773,11 +16123,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15794,11 +16145,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15807,8 +16159,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15816,11 +16168,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15829,11 +16182,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15842,7 +16196,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15851,33 +16205,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15886,7 +16219,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15895,11 +16228,35 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15911,7 +16268,7 @@
     <measure implicit="no" number="82">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15920,11 +16277,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15933,7 +16291,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15960,8 +16318,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15970,6 +16328,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15978,7 +16337,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16004,8 +16363,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16014,6 +16373,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16030,8 +16390,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16039,11 +16399,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16052,8 +16413,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16062,6 +16423,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16083,7 +16445,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16109,8 +16471,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16119,6 +16481,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16138,7 +16501,7 @@
     <measure implicit="no" number="83">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16164,8 +16527,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16174,6 +16537,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16187,8 +16551,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16204,8 +16568,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16214,6 +16578,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16239,8 +16604,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16249,6 +16614,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16265,7 +16631,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16291,8 +16657,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16301,6 +16667,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16314,7 +16681,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16331,8 +16698,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16341,6 +16708,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16366,8 +16734,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16380,8 +16748,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16390,6 +16758,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16409,8 +16778,8 @@
     <measure implicit="no" number="84">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16419,6 +16788,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16444,7 +16814,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16461,8 +16831,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16471,12 +16841,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16485,6 +16856,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16510,7 +16882,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16524,8 +16896,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16534,6 +16906,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16550,8 +16923,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16576,8 +16949,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16586,6 +16959,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16599,8 +16973,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16609,6 +16983,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -16620,7 +16995,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16629,11 +17004,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16645,7 +17021,7 @@
     <measure implicit="no" number="85">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16654,11 +17030,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16667,8 +17044,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16676,11 +17053,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16689,11 +17067,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16702,7 +17081,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16711,11 +17090,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16724,7 +17104,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16733,11 +17113,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16746,8 +17127,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16755,11 +17136,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16771,11 +17153,12 @@
     <measure implicit="no" number="86">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16784,7 +17167,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16793,11 +17176,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16806,7 +17190,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16815,11 +17199,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16828,8 +17213,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16837,11 +17222,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16850,11 +17236,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16863,7 +17250,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16872,11 +17259,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16885,7 +17273,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16894,11 +17282,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 87 =========================-->
@@ -16910,8 +17299,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16919,11 +17308,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16932,11 +17322,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16945,7 +17336,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16954,11 +17345,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16967,7 +17359,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16976,11 +17368,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16989,8 +17382,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16998,11 +17391,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17011,11 +17405,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 88 =========================-->
@@ -17027,7 +17422,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17036,11 +17431,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17049,7 +17445,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17058,11 +17454,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17071,8 +17468,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17080,11 +17477,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17093,11 +17491,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17106,7 +17505,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17115,11 +17514,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17128,7 +17528,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17137,18 +17537,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 89 =========================-->
     <measure implicit="no" number="89">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -17174,8 +17575,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -17184,6 +17585,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17222,8 +17624,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17239,8 +17641,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17249,6 +17651,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17275,11 +17678,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17288,7 +17692,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17315,8 +17719,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17325,6 +17729,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17333,7 +17738,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17359,8 +17764,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17369,6 +17774,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17385,8 +17791,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17394,11 +17800,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17407,7 +17814,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17416,18 +17823,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 90 =========================-->
     <measure implicit="no" number="90">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -17453,8 +17861,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -17463,6 +17871,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17501,7 +17910,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17518,8 +17927,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17528,6 +17937,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17553,7 +17963,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17567,8 +17977,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17577,6 +17987,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17593,8 +18004,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17619,8 +18030,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17629,6 +18040,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17642,7 +18054,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17659,8 +18071,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17669,6 +18081,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17694,7 +18107,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17708,8 +18121,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17718,6 +18131,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17734,7 +18148,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17761,8 +18175,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17771,6 +18185,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 91 =========================-->
@@ -17799,8 +18214,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17813,8 +18228,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17823,6 +18238,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17839,7 +18255,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17865,8 +18281,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17875,6 +18291,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17888,7 +18305,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17905,8 +18322,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17915,6 +18332,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17940,7 +18358,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17954,8 +18372,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17964,6 +18382,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17980,8 +18399,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18006,8 +18425,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18016,6 +18435,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18029,8 +18449,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18039,6 +18459,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -18053,7 +18474,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18062,11 +18483,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18075,7 +18497,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18084,11 +18506,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18097,8 +18520,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18106,11 +18529,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18119,11 +18543,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18132,7 +18557,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18141,11 +18566,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18154,7 +18580,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18163,11 +18589,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18184,8 +18611,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18193,11 +18620,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18206,11 +18634,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18219,7 +18648,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18228,11 +18657,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18241,7 +18671,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18250,11 +18680,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18263,8 +18694,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18272,11 +18703,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18285,11 +18717,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18301,7 +18734,7 @@
     <measure implicit="no" number="94">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18310,11 +18743,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18323,7 +18757,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18332,11 +18766,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18345,8 +18780,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18354,11 +18789,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18367,11 +18803,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18380,7 +18817,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18389,11 +18826,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18402,7 +18840,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18411,11 +18849,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18427,8 +18866,8 @@
     <measure implicit="no" number="95">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18436,11 +18875,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18449,8 +18889,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18459,6 +18899,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -18480,7 +18921,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18506,8 +18947,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18516,6 +18957,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18529,7 +18971,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18546,8 +18988,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18556,6 +18998,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18581,8 +19024,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18595,8 +19038,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18605,6 +19048,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18621,8 +19065,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18631,6 +19075,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -18662,7 +19107,7 @@
     <measure implicit="no" number="96">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18688,8 +19133,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18698,6 +19143,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18711,7 +19157,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18728,8 +19174,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18738,6 +19184,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18746,8 +19193,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18755,20 +19202,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18777,11 +19226,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18790,7 +19240,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18799,11 +19249,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18812,7 +19263,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18821,11 +19272,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18837,8 +19289,8 @@
     <measure implicit="no" number="97">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18846,11 +19298,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18859,11 +19312,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18872,7 +19326,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18881,11 +19335,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18894,7 +19349,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18903,11 +19358,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18916,8 +19372,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18925,11 +19381,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18938,11 +19395,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18951,7 +19409,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18960,11 +19418,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 98 =========================-->
@@ -18976,7 +19435,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18985,11 +19444,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18998,17 +19458,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19020,11 +19481,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19033,7 +19495,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19042,11 +19504,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19055,7 +19518,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19064,11 +19527,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19077,17 +19541,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19102,11 +19567,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19115,7 +19581,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19124,11 +19590,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19137,7 +19604,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19164,8 +19631,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19174,6 +19641,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19182,8 +19650,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19208,8 +19676,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19218,6 +19686,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19231,7 +19700,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19248,8 +19717,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19258,6 +19727,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19283,7 +19753,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19300,8 +19770,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19310,6 +19780,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 100 =========================-->
@@ -19338,7 +19809,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19352,8 +19823,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19362,6 +19833,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19378,8 +19850,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19404,8 +19876,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19414,6 +19886,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19427,8 +19900,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19437,6 +19910,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -19465,7 +19939,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19479,8 +19953,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19489,6 +19963,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19505,7 +19980,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19531,8 +20006,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19541,6 +20016,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19554,8 +20030,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19571,8 +20047,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19581,12 +20057,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19595,6 +20072,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 101 =========================-->
@@ -19606,7 +20084,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19615,11 +20093,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19628,7 +20107,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19637,20 +20116,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19659,7 +20140,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19672,8 +20153,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19682,8 +20163,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19692,8 +20173,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19707,7 +20188,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19716,11 +20197,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19758,8 +20240,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19768,6 +20250,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -19826,8 +20309,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19836,6 +20319,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -19847,8 +20331,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19858,16 +20342,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19881,8 +20365,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19891,18 +20375,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19911,11 +20396,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19924,8 +20410,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19934,8 +20420,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19947,8 +20433,8 @@
     <measure implicit="no" number="107">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19973,8 +20459,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19987,8 +20473,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20004,7 +20490,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20030,8 +20516,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20040,6 +20526,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20053,8 +20540,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20070,8 +20557,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20080,6 +20567,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20105,8 +20593,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20115,12 +20603,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20136,8 +20625,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20146,6 +20635,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -20162,8 +20652,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20176,7 +20666,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20218,8 +20708,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20249,8 +20739,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20275,8 +20765,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20298,7 +20788,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20315,8 +20805,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20325,6 +20815,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20333,7 +20824,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20342,11 +20833,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20355,8 +20847,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20368,11 +20860,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20384,20 +20877,22 @@
     <measure implicit="no" number="109">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20406,8 +20901,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20416,7 +20911,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20427,11 +20922,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20440,8 +20936,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20449,11 +20945,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20462,27 +20959,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20492,7 +20990,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20501,11 +20999,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20515,7 +21014,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20524,11 +21023,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20540,8 +21040,8 @@
     <measure implicit="no" number="110">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20566,8 +21066,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20576,6 +21076,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20589,8 +21090,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20599,6 +21100,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -20606,8 +21108,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20616,11 +21118,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20645,8 +21148,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20655,12 +21158,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20676,7 +21180,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20702,8 +21206,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20712,6 +21216,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20725,8 +21230,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20742,8 +21247,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20752,6 +21257,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20777,8 +21283,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20787,12 +21293,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20817,7 +21324,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20826,20 +21342,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 111 =========================-->
@@ -20851,7 +21359,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20860,11 +21368,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20873,8 +21382,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20882,11 +21391,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20895,11 +21405,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20908,8 +21419,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20918,18 +21429,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20938,7 +21450,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20947,11 +21459,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20960,8 +21473,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20969,27 +21482,29 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 112 =========================-->
     <measure implicit="no" number="112">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21002,17 +21517,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21022,7 +21538,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21048,8 +21564,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21058,6 +21574,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21071,7 +21588,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21088,8 +21605,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21098,6 +21615,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21123,8 +21641,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21162,7 +21680,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21171,11 +21689,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21184,8 +21703,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21193,11 +21712,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21206,7 +21726,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21215,11 +21735,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21228,7 +21749,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21237,11 +21758,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21250,17 +21772,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21280,7 +21803,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21291,16 +21814,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21309,8 +21833,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21320,16 +21844,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21341,7 +21866,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21350,11 +21875,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21363,8 +21889,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21372,11 +21898,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21385,17 +21912,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21407,7 +21935,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21416,20 +21953,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21441,7 +21970,7 @@
     <measure implicit="no" number="115">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21467,8 +21996,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21477,6 +22006,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21490,8 +22020,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21507,8 +22037,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21517,11 +22047,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21546,7 +22077,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21561,8 +22092,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21571,11 +22102,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21591,11 +22123,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21604,7 +22137,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21613,11 +22146,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21626,8 +22160,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21636,8 +22170,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21647,11 +22181,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21663,8 +22198,8 @@
     <measure implicit="no" number="116">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21672,8 +22207,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21685,7 +22220,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21694,11 +22229,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21707,7 +22243,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21716,8 +22252,40 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21727,50 +22295,21 @@
         <duration>2520</duration>
         <type>16th</type>
       </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21779,8 +22318,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21789,6 +22328,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -21805,8 +22345,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21832,7 +22372,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21841,18 +22381,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 117 =========================-->
     <measure implicit="no" number="117">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -21878,8 +22419,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -21888,6 +22429,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21926,8 +22468,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21943,8 +22485,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21953,6 +22495,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21978,8 +22521,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21988,12 +22531,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22009,8 +22553,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22019,6 +22563,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -22036,8 +22581,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22046,7 +22591,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22057,11 +22602,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22070,8 +22616,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22083,7 +22629,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22092,11 +22638,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22113,11 +22660,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22126,7 +22674,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22135,11 +22683,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22148,8 +22697,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22157,11 +22706,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22170,7 +22720,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22179,11 +22729,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22192,7 +22743,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22201,11 +22752,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22217,8 +22769,8 @@
     <measure implicit="no" number="119">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22244,8 +22796,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22254,11 +22806,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22284,8 +22837,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22310,8 +22863,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22320,6 +22873,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -22337,7 +22891,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22363,8 +22917,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22373,6 +22927,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22386,8 +22941,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22403,8 +22958,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22413,6 +22968,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22438,8 +22994,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22448,6 +23004,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22467,7 +23024,7 @@
     <measure implicit="no" number="120">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22476,11 +23033,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22489,7 +23047,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22498,80 +23056,83 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
         <duration>5040</duration>
         <type>eighth</type>
       </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22580,7 +23141,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22591,11 +23152,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22604,8 +23166,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22613,11 +23175,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 121 =========================-->
@@ -22629,11 +23192,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22642,7 +23206,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22651,11 +23215,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22664,7 +23229,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22691,8 +23256,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22701,6 +23266,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22709,8 +23275,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22735,8 +23301,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22745,6 +23311,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22761,16 +23328,16 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22779,6 +23346,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -22795,8 +23363,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22822,12 +23390,13 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="start" />
         </notations>
@@ -22837,8 +23406,8 @@
     <measure implicit="no" number="122">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -22848,6 +23417,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tied type="stop" />
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -22899,7 +23469,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22916,8 +23486,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22926,6 +23496,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22952,8 +23523,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22965,8 +23536,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22978,8 +23549,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22988,7 +23559,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22999,11 +23570,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23012,7 +23584,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23025,8 +23597,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23046,18 +23618,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23066,7 +23639,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23077,11 +23650,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23090,8 +23664,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23101,16 +23675,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23119,11 +23694,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -23134,7 +23710,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23143,11 +23719,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23159,7 +23736,7 @@
     <measure implicit="no" number="124">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23185,8 +23762,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23195,6 +23772,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23208,8 +23786,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23246,8 +23824,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23256,6 +23834,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23272,11 +23851,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23285,7 +23865,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23294,20 +23883,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23316,8 +23897,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23325,11 +23906,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23341,8 +23923,8 @@
     <measure implicit="no" number="125">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23351,6 +23933,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -23368,8 +23951,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23381,8 +23964,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23396,7 +23979,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23410,8 +23993,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23420,6 +24003,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23441,7 +24025,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23450,11 +24034,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23463,8 +24048,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23472,11 +24057,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23485,8 +24071,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23499,8 +24085,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23509,6 +24095,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -23534,8 +24121,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23544,6 +24131,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -23551,7 +24139,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23565,8 +24153,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23575,6 +24163,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 126 =========================-->
@@ -23586,8 +24175,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23595,11 +24184,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23609,8 +24199,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23636,7 +24226,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23650,8 +24240,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23660,6 +24250,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23668,7 +24259,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23694,8 +24285,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23704,6 +24295,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23717,8 +24309,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23734,8 +24326,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23744,6 +24336,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23769,8 +24362,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23786,8 +24379,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23796,13 +24389,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 127 =========================-->
     <measure implicit="no" number="127">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23828,8 +24422,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23838,12 +24432,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23859,7 +24454,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23868,11 +24463,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23881,8 +24477,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23890,20 +24486,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23912,7 +24510,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>

--- a/public/transcription-samples/cant-stop/adtof-plus-drums/ADP61c3e564bfff_drum_transcription.musicxml
+++ b/public/transcription-samples/cant-stop/adtof-plus-drums/ADP61c3e564bfff_drum_transcription.musicxml
@@ -5,8 +5,11 @@
   <identification>
     <creator type="composer">Music21</creator>
     <encoding>
-      <encoding-date>2026-07-03</encoding-date>
-      <software>music21 v.9.9.2</software>
+      <encoding-date>2026-07-05</encoding-date>
+      <software>music21 v.10.5.0</software>
+      <supports element="beam" type="yes" />
+      <supports element="stem" type="yes" />
+      <supports element="accidental" type="yes" />
     </encoding>
   </identification>
   <defaults>
@@ -16,21 +19,21 @@
     </scaling>
   </defaults>
   <part-list>
-    <score-part id="P43d561d1918e429c5dc131ac25979431">
+    <score-part id="Pac52995ddfe20267746ecfa749fdc047">
       <part-name>Percussion</part-name>
       <part-abbreviation>Perc</part-abbreviation>
-      <score-instrument id="Ib0c7e33877ff70249ad6326b19469f92">
+      <score-instrument id="I35cb9b3896dc3ffaadad779ff5d6e9a7">
         <instrument-name>Percussion</instrument-name>
         <instrument-abbreviation>Perc</instrument-abbreviation>
       </score-instrument>
-      <midi-instrument id="Ib0c7e33877ff70249ad6326b19469f92">
+      <midi-instrument id="I35cb9b3896dc3ffaadad779ff5d6e9a7">
         <midi-channel>10</midi-channel>
         <midi-program>1</midi-program>
       </midi-instrument>
     </score-part>
   </part-list>
   <!--=========================== Part 1 ===========================-->
-  <part id="P43d561d1918e429c5dc131ac25979431">
+  <part id="Pac52995ddfe20267746ecfa749fdc047">
     <!--========================= Measure 1 ==========================-->
     <measure implicit="no" number="1">
       <attributes>
@@ -40,8 +43,7 @@
           <beat-type>4</beat-type>
         </time>
         <clef>
-          <sign>G</sign>
-          <line>2</line>
+          <sign>percussion</sign>
         </clef>
       </attributes>
       <direction>
@@ -77,8 +79,8 @@
       </note>
       <note dynamics="85.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -96,8 +98,8 @@
     <measure implicit="no" number="2">
       <note dynamics="83.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -122,8 +124,8 @@
       </note>
       <note dynamics="76.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -136,8 +138,8 @@
       </note>
       <note dynamics="81.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -153,8 +155,8 @@
       </note>
       <note dynamics="78.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -179,8 +181,8 @@
       </note>
       <note dynamics="74.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -193,8 +195,8 @@
       </note>
       <note dynamics="80.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -210,8 +212,8 @@
       </note>
       <note dynamics="73.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -236,8 +238,8 @@
       </note>
       <note dynamics="78.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -263,16 +265,16 @@
       </note>
       <note dynamics="75.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="78.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -297,8 +299,8 @@
       </note>
       <note dynamics="77.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -324,8 +326,8 @@
       </note>
       <note dynamics="80.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -335,8 +337,8 @@
     <measure implicit="no" number="3">
       <note dynamics="76.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -361,8 +363,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -376,8 +378,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -402,16 +404,16 @@
       </note>
       <note dynamics="78.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -437,8 +439,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -450,8 +452,8 @@
       </note>
       <note dynamics="83.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -477,16 +479,16 @@
       </note>
       <note dynamics="83.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -494,8 +496,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -507,8 +509,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -518,16 +520,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -537,16 +539,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="84.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -558,8 +560,8 @@
       </note>
       <note dynamics="77.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -568,8 +570,8 @@
       </note>
       <note dynamics="85.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -581,8 +583,8 @@
     <measure implicit="no" number="4">
       <note dynamics="80.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -594,8 +596,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -605,16 +607,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="82.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -623,8 +625,8 @@
       </note>
       <note dynamics="80.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -636,8 +638,8 @@
       </note>
       <note dynamics="83.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -646,8 +648,8 @@
       </note>
       <note dynamics="87.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -656,8 +658,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -665,8 +667,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -678,8 +680,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -689,16 +691,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="85.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -707,8 +709,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -716,8 +718,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -729,8 +731,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -740,8 +742,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -749,16 +751,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -768,8 +770,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -784,8 +786,8 @@
       </note>
       <note dynamics="78.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -794,8 +796,8 @@
       </note>
       <note dynamics="88.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -804,8 +806,8 @@
       </note>
       <note dynamics="84.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -819,8 +821,8 @@
       </note>
       <note dynamics="92.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -829,8 +831,8 @@
       </note>
       <note dynamics="86.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -839,8 +841,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -850,8 +852,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -863,8 +865,8 @@
       </note>
       <note dynamics="88.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -873,8 +875,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -884,8 +886,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -893,16 +895,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -912,8 +914,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -925,8 +927,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -936,16 +938,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -955,8 +957,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -964,16 +966,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -983,8 +985,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -992,8 +994,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1008,8 +1010,8 @@
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1018,8 +1020,8 @@
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1028,8 +1030,8 @@
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1043,8 +1045,8 @@
       </note>
       <note dynamics="94.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1053,8 +1055,8 @@
       </note>
       <note dynamics="94.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1063,8 +1065,8 @@
       </note>
       <note dynamics="91.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1078,8 +1080,8 @@
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1088,8 +1090,8 @@
       </note>
       <note dynamics="92.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1098,8 +1100,8 @@
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1113,8 +1115,8 @@
       </note>
       <note dynamics="94.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1123,8 +1125,8 @@
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1133,8 +1135,8 @@
       </note>
       <note dynamics="98.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1151,8 +1153,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1162,16 +1164,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1185,8 +1187,8 @@
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1195,8 +1197,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1206,16 +1208,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1225,8 +1227,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1238,8 +1240,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1249,16 +1251,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1268,16 +1270,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1287,8 +1289,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1300,8 +1302,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1311,16 +1313,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1330,16 +1332,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1349,8 +1351,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1358,16 +1360,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1377,8 +1379,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1386,8 +1388,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1402,8 +1404,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1413,16 +1415,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1432,8 +1434,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1441,8 +1443,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1454,8 +1456,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1465,8 +1467,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1474,16 +1476,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1493,8 +1495,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1502,16 +1504,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1521,8 +1523,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1534,8 +1536,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1545,8 +1547,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1554,16 +1556,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1573,16 +1575,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1592,8 +1594,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1605,8 +1607,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1616,16 +1618,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1635,16 +1637,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1654,8 +1656,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1663,8 +1665,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1679,8 +1681,8 @@
     <measure implicit="no" number="9">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1690,16 +1692,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1709,8 +1711,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1718,16 +1720,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1737,8 +1739,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1746,8 +1748,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1759,8 +1761,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1770,8 +1772,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1779,16 +1781,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1814,8 +1816,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1828,8 +1830,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1851,8 +1853,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1868,8 +1870,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1881,8 +1883,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1892,16 +1894,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1927,8 +1929,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1941,8 +1943,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1964,8 +1966,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1981,8 +1983,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1995,8 +1997,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2008,8 +2010,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2019,8 +2021,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2028,16 +2030,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2063,8 +2065,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2086,8 +2088,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2103,8 +2105,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2119,8 +2121,8 @@
     <measure implicit="no" number="10">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2146,8 +2148,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2160,8 +2162,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2173,8 +2175,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2188,8 +2190,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2202,8 +2204,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2215,8 +2217,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2233,8 +2235,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2247,8 +2249,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2260,8 +2262,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2287,8 +2289,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2301,8 +2303,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2314,8 +2316,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2329,8 +2331,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2343,8 +2345,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2356,8 +2358,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2374,8 +2376,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2388,8 +2390,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2401,8 +2403,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2428,8 +2430,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2442,8 +2444,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2455,8 +2457,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2470,8 +2472,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2484,8 +2486,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2497,8 +2499,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2515,8 +2517,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2529,8 +2531,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2542,8 +2544,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2569,8 +2571,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2583,8 +2585,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2596,8 +2598,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2611,8 +2613,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2625,8 +2627,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2638,8 +2640,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2656,8 +2658,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2670,8 +2672,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2686,8 +2688,8 @@
     <measure implicit="no" number="11">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2713,8 +2715,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2727,8 +2729,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2740,8 +2742,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2755,8 +2757,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2769,8 +2771,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2782,8 +2784,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2800,8 +2802,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2813,8 +2815,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2840,8 +2842,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2854,8 +2856,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2867,8 +2869,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2882,8 +2884,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2896,8 +2898,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2909,8 +2911,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2927,8 +2929,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2941,8 +2943,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2954,8 +2956,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2981,8 +2983,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2995,8 +2997,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3008,8 +3010,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3023,8 +3025,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3049,8 +3051,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3058,16 +3060,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3093,8 +3095,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3107,8 +3109,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3120,8 +3122,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3135,8 +3137,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3161,8 +3163,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3170,8 +3172,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3181,8 +3183,8 @@
     <measure implicit="no" number="12">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3208,8 +3210,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3221,8 +3223,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3236,8 +3238,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3250,8 +3252,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3276,8 +3278,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3285,16 +3287,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3320,8 +3322,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3334,8 +3336,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3347,8 +3349,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3362,8 +3364,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3376,8 +3378,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3402,8 +3404,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3411,16 +3413,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3446,8 +3448,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3460,8 +3462,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3473,8 +3475,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3488,7 +3490,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3502,8 +3504,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3516,8 +3518,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3539,7 +3541,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3556,8 +3558,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3570,8 +3572,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3664,8 +3666,8 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3683,7 +3685,7 @@
     <measure implicit="no" number="18">
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3718,7 +3720,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3735,8 +3737,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3745,6 +3747,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3753,8 +3756,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3762,8 +3765,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3771,11 +3774,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3784,18 +3788,19 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3805,19 +3810,20 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -3828,7 +3834,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3837,11 +3843,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3853,8 +3860,8 @@
     <measure implicit="no" number="19">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3862,8 +3869,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3871,11 +3878,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3884,11 +3892,12 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3897,7 +3906,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3906,11 +3915,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3919,7 +3929,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3928,11 +3938,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3941,8 +3952,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3950,11 +3961,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3963,18 +3975,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3982,8 +3995,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3992,7 +4005,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4003,11 +4016,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 20 =========================-->
@@ -4019,8 +4033,8 @@
       </note>
       <note dynamics="106.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4029,7 +4043,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4040,11 +4054,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4053,8 +4068,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4062,11 +4077,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4075,11 +4091,12 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4088,7 +4105,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4097,20 +4123,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4120,7 +4138,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4129,11 +4147,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4142,8 +4161,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4151,11 +4170,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 21 =========================-->
@@ -4167,8 +4187,8 @@
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4177,7 +4197,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4188,16 +4208,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4207,15 +4228,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4224,11 +4245,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4237,8 +4259,8 @@
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4247,7 +4269,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4258,11 +4280,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4271,8 +4294,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4280,8 +4313,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4289,20 +4322,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4311,20 +4336,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4333,8 +4360,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4359,7 +4386,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4373,8 +4400,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4383,6 +4410,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4424,7 +4452,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4438,8 +4466,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4448,6 +4476,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4464,8 +4493,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4474,6 +4503,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4490,8 +4520,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4504,8 +4534,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4514,6 +4544,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4527,7 +4558,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4544,8 +4575,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4554,11 +4585,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4584,8 +4616,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4597,8 +4629,8 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4607,12 +4639,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4629,8 +4662,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4642,7 +4675,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4668,8 +4701,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4678,6 +4711,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4691,8 +4725,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4708,8 +4742,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4722,8 +4756,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4732,11 +4766,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4757,7 +4792,7 @@
       </note>
       <note dynamics="138.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4792,7 +4827,7 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4813,8 +4848,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4822,11 +4857,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4835,7 +4871,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4846,16 +4882,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4881,8 +4918,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4904,8 +4941,8 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4914,6 +4951,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4923,8 +4961,8 @@
     <measure implicit="no" number="24">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4934,15 +4972,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4953,11 +4991,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4966,8 +5005,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4975,8 +5014,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4984,11 +5023,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4997,7 +5037,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5006,33 +5046,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5041,7 +5060,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5050,11 +5069,35 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5063,8 +5106,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5072,8 +5115,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5081,11 +5124,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5102,7 +5146,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5113,16 +5157,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5132,8 +5177,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5145,18 +5190,19 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5165,7 +5211,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5176,19 +5222,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="83.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -5199,8 +5247,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5225,8 +5273,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5235,6 +5283,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5248,8 +5297,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5258,6 +5307,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -5265,8 +5315,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5275,6 +5325,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5283,7 +5334,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5292,20 +5352,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5322,7 +5374,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5331,11 +5383,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5344,8 +5397,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5353,8 +5406,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5362,11 +5415,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5375,18 +5429,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5396,8 +5451,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5409,18 +5464,19 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5430,15 +5486,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5449,11 +5505,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5462,8 +5519,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5471,17 +5528,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5496,20 +5554,22 @@
     <measure implicit="no" number="27">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5518,7 +5578,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5527,11 +5587,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5540,7 +5601,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5549,11 +5610,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5562,8 +5624,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5588,8 +5650,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5602,8 +5664,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5612,6 +5674,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5625,7 +5688,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5642,8 +5705,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5652,11 +5715,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5664,8 +5728,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5677,18 +5741,19 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5700,7 +5765,7 @@
     <measure implicit="no" number="28">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5709,11 +5774,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5722,8 +5788,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5749,8 +5815,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5763,8 +5829,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5773,6 +5839,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5781,7 +5848,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5808,8 +5875,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5818,11 +5885,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5836,8 +5904,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5850,8 +5918,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5860,10 +5928,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5881,8 +5950,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5891,11 +5960,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5921,8 +5991,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5934,7 +6004,7 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5961,8 +6031,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5987,8 +6057,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5997,12 +6067,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6030,8 +6101,8 @@
     <measure implicit="no" number="29">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6040,6 +6111,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -6057,8 +6129,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6070,8 +6142,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6085,8 +6157,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6098,8 +6170,8 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6108,6 +6180,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -6115,8 +6188,8 @@
       </note>
       <note dynamics="84.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6125,7 +6198,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6136,11 +6209,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6149,8 +6223,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6175,8 +6249,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6185,12 +6259,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6212,8 +6287,8 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6222,6 +6297,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -6233,7 +6309,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6242,11 +6318,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6258,7 +6335,7 @@
     <measure implicit="no" number="30">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6284,8 +6361,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6294,6 +6371,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6307,8 +6385,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6324,8 +6402,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6334,12 +6412,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6356,8 +6435,8 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6366,6 +6445,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6391,8 +6471,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6408,8 +6488,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6421,18 +6501,19 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6441,7 +6522,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6452,11 +6533,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6465,8 +6547,8 @@
       </note>
       <note dynamics="73.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6475,8 +6557,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6486,8 +6568,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6495,11 +6577,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6511,11 +6594,12 @@
     <measure implicit="no" number="31">
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6524,7 +6608,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6533,11 +6617,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6546,7 +6631,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6555,11 +6640,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6568,8 +6654,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6577,11 +6663,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6590,8 +6677,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6601,19 +6688,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="106.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -6624,8 +6713,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6635,37 +6724,39 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6673,15 +6764,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6692,11 +6783,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 32 =========================-->
@@ -6708,8 +6800,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6717,8 +6809,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6726,11 +6818,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6739,11 +6832,12 @@
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6752,7 +6846,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6761,11 +6855,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6774,7 +6869,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6783,11 +6878,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6796,8 +6892,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6805,8 +6911,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6814,20 +6920,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6836,19 +6934,20 @@
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 33 =========================-->
     <measure implicit="no" number="33">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6856,8 +6955,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6869,18 +6968,19 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6890,15 +6990,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6907,11 +7007,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6920,8 +7021,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6929,17 +7030,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6951,20 +7053,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6973,7 +7077,25 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6982,28 +7104,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7012,7 +7118,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7021,18 +7127,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 34 =========================-->
     <measure implicit="no" number="34">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -7058,8 +7165,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -7068,6 +7175,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7106,8 +7214,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7123,8 +7231,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7137,8 +7245,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7147,6 +7255,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7172,8 +7281,8 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7182,12 +7291,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7204,8 +7314,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7217,8 +7327,8 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7227,6 +7337,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -7243,8 +7354,8 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7257,7 +7368,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7275,8 +7386,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7285,6 +7396,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7310,8 +7422,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7324,8 +7436,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7334,6 +7446,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7350,8 +7463,8 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7360,6 +7473,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7401,7 +7515,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7415,8 +7529,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7425,6 +7539,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7441,7 +7556,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7450,20 +7574,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7472,8 +7588,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7481,8 +7607,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7490,20 +7616,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7512,8 +7630,8 @@
       </note>
       <note dynamics="91.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7538,8 +7656,8 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7548,12 +7666,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7570,8 +7689,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7583,8 +7702,8 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7593,6 +7712,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -7609,8 +7729,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7624,8 +7744,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7637,7 +7757,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7655,8 +7775,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7665,6 +7785,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 36 =========================-->
@@ -7676,8 +7797,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7685,8 +7806,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7694,11 +7815,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7707,8 +7829,8 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7717,6 +7839,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -7733,8 +7856,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7743,12 +7866,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7762,8 +7886,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7772,6 +7896,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7793,7 +7918,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7802,11 +7927,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7815,8 +7941,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7824,17 +7950,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7846,11 +7973,12 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7862,8 +7990,8 @@
     <measure implicit="no" number="37">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7873,26 +8001,27 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7902,15 +8031,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7921,11 +8050,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7934,8 +8064,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7943,8 +8073,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7952,11 +8082,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7965,18 +8096,19 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7985,7 +8117,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7996,11 +8128,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8009,7 +8142,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8018,11 +8151,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8034,8 +8168,8 @@
     <measure implicit="no" number="38">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8043,8 +8177,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8052,11 +8186,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8065,11 +8200,12 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8078,7 +8214,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8089,16 +8225,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8108,16 +8245,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8126,6 +8263,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8143,8 +8281,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8157,8 +8295,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8170,8 +8308,8 @@
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8184,7 +8322,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8202,8 +8340,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8216,8 +8354,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8235,7 +8373,7 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8246,7 +8384,7 @@
     <measure implicit="no" number="39">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8272,8 +8410,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8282,6 +8420,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8295,8 +8434,8 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8305,6 +8444,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -8333,8 +8473,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8347,8 +8487,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8373,8 +8513,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8399,7 +8539,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8422,8 +8562,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8439,8 +8579,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8449,11 +8589,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8479,8 +8620,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8492,7 +8633,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8507,8 +8648,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8517,6 +8658,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8536,8 +8678,8 @@
     <measure implicit="no" number="40">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8545,17 +8687,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8567,11 +8710,12 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8580,7 +8724,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8589,20 +8733,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8611,11 +8757,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8624,8 +8771,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8637,8 +8784,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8648,16 +8795,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8665,8 +8813,8 @@
       </note>
       <note dynamics="77.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8683,27 +8831,28 @@
     <measure implicit="no" number="41">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8713,15 +8862,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8732,8 +8881,54 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8745,51 +8940,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8800,16 +8951,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="76.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8823,17 +8975,18 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8843,8 +8996,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8854,8 +9007,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8870,7 +9023,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8880,8 +9033,8 @@
       </note>
       <note dynamics="78.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8890,11 +9043,12 @@
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8903,8 +9057,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8914,15 +9068,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8950,8 +9104,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8960,6 +9114,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8968,7 +9123,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8994,8 +9149,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9008,8 +9163,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9031,7 +9186,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9049,8 +9204,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9059,11 +9214,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9101,7 +9257,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9110,8 +9266,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9121,8 +9277,8 @@
     <measure implicit="no" number="43">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9148,8 +9304,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9161,8 +9317,8 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9171,6 +9327,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -9188,7 +9345,7 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9196,8 +9353,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9222,8 +9379,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9236,8 +9393,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9246,6 +9403,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9259,7 +9417,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9275,8 +9433,8 @@
       </note>
       <note dynamics="75.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9301,8 +9459,8 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9311,12 +9469,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9333,8 +9492,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9346,7 +9505,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9355,11 +9514,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9368,7 +9528,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9377,8 +9537,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9386,8 +9546,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9407,7 +9567,7 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9420,7 +9580,7 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9433,11 +9593,12 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9446,7 +9607,7 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9456,8 +9617,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9467,8 +9628,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9480,7 +9641,7 @@
       </note>
       <note dynamics="137.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9493,8 +9654,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9502,8 +9663,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9518,8 +9679,8 @@
     <measure implicit="no" number="45">
       <note dynamics="91.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9528,8 +9689,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9539,16 +9700,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9561,8 +9723,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9570,17 +9742,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9592,7 +9755,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9601,7 +9764,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9614,8 +9777,8 @@
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9627,7 +9790,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9638,16 +9801,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="76.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9661,28 +9825,30 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9690,8 +9856,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9701,8 +9867,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9722,16 +9888,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9744,17 +9911,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9766,7 +9934,7 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9779,8 +9947,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9788,8 +9956,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9797,7 +9965,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9810,16 +9978,17 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9831,7 +10000,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9842,16 +10011,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="77.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9868,17 +10038,18 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9888,8 +10059,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9916,8 +10087,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9934,7 +10105,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9960,8 +10131,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9970,6 +10141,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9986,11 +10158,12 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9999,8 +10172,8 @@
       </note>
       <note dynamics="72.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10009,7 +10182,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10037,8 +10210,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10047,6 +10220,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -10055,8 +10229,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10081,8 +10255,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10095,8 +10269,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10105,6 +10279,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -10121,20 +10296,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 48 =========================-->
@@ -10146,8 +10323,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10172,8 +10349,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10195,7 +10372,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10209,8 +10386,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10219,6 +10396,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10257,7 +10435,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10271,8 +10449,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10281,6 +10459,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10327,8 +10506,8 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10350,8 +10529,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10367,8 +10546,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10385,8 +10564,8 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10395,6 +10574,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10423,7 +10603,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10432,20 +10622,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10455,8 +10637,8 @@
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10465,6 +10647,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10486,8 +10669,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10513,8 +10696,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10523,11 +10706,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="94.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10546,8 +10730,8 @@
     <measure implicit="no" number="50">
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10556,6 +10740,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -10572,8 +10757,8 @@
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10596,8 +10781,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10606,6 +10791,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -10617,7 +10803,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10643,8 +10829,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10653,6 +10839,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10666,8 +10853,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10684,8 +10871,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10694,11 +10881,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="92.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10723,8 +10911,8 @@
       </note>
       <note dynamics="91.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10733,12 +10921,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note dynamics="91.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10754,7 +10943,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10781,8 +10970,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10791,6 +10980,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10810,7 +11000,7 @@
     <measure implicit="no" number="51">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10836,8 +11026,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10846,6 +11036,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10859,8 +11050,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10876,8 +11067,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10886,6 +11077,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -10911,8 +11103,8 @@
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10921,12 +11113,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10942,8 +11135,8 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10952,6 +11145,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10977,7 +11171,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10994,8 +11188,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11004,6 +11198,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11012,8 +11207,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11021,17 +11216,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11046,8 +11242,8 @@
     <measure implicit="no" number="52">
       <note dynamics="87.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11056,6 +11252,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11081,7 +11278,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11098,8 +11295,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11108,6 +11305,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11116,7 +11314,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11125,11 +11323,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11138,8 +11337,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11164,8 +11363,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11174,6 +11373,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11187,8 +11387,8 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11197,14 +11397,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11214,26 +11415,27 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11250,7 +11452,7 @@
     <measure implicit="no" number="53">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11259,11 +11461,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11272,8 +11475,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11281,11 +11484,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11294,8 +11498,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11304,6 +11508,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -11320,8 +11525,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11343,7 +11548,21 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11357,8 +11576,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11367,20 +11586,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11397,9 +11603,117 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
+        <notations>
+          <tuplet bracket="yes" number="1" placement="above" type="start">
+            <tuplet-actual>
+              <tuplet-number>3</tuplet-number>
+              <tuplet-type>eighth</tuplet-type>
+            </tuplet-actual>
+            <tuplet-normal>
+              <tuplet-number>2</tuplet-number>
+              <tuplet-type>eighth</tuplet-type>
+            </tuplet-normal>
+          </tuplet>
+        </notations>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+        <notations>
+          <tuplet number="1" type="stop" />
+        </notations>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
         <duration>3360</duration>
         <type>eighth</type>
         <time-modification>
@@ -11421,10 +11735,9 @@
         </notations>
       </note>
       <note>
-        <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11433,43 +11746,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <rest />
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -11477,8 +11754,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11487,80 +11764,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <rest />
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <notations>
-          <tuplet bracket="yes" number="1" placement="above" type="start">
-            <tuplet-actual>
-              <tuplet-number>3</tuplet-number>
-              <tuplet-type>eighth</tuplet-type>
-            </tuplet-actual>
-            <tuplet-normal>
-              <tuplet-number>2</tuplet-number>
-              <tuplet-type>eighth</tuplet-type>
-            </tuplet-normal>
-          </tuplet>
-        </notations>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <notations>
-          <tuplet number="1" type="stop" />
-        </notations>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 54 =========================-->
     <measure implicit="no" number="54">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11568,8 +11780,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11581,18 +11793,19 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11602,15 +11815,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11619,11 +11833,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11632,8 +11847,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11641,11 +11856,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11654,18 +11870,19 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11675,8 +11892,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11684,19 +11901,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11705,8 +11924,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11716,15 +11935,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11735,11 +11954,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 55 =========================-->
@@ -11751,8 +11971,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11760,17 +11990,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11782,16 +12003,16 @@
       </note>
       <note dynamics="98.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="98.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11800,6 +12021,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -11816,8 +12038,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11831,8 +12053,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11857,16 +12079,17 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11892,8 +12115,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11905,7 +12128,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11920,8 +12143,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11930,6 +12153,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11946,8 +12170,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11972,8 +12196,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11982,12 +12206,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12009,8 +12234,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12019,6 +12244,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -12026,8 +12252,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12064,7 +12290,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12078,8 +12304,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12088,6 +12314,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12104,7 +12331,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12130,8 +12357,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12140,6 +12367,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12153,8 +12381,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12191,8 +12419,8 @@
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12201,12 +12429,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12223,8 +12452,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12236,18 +12465,19 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note dynamics="91.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12282,7 +12512,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12299,8 +12529,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12309,6 +12539,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 57 =========================-->
@@ -12320,8 +12551,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12346,8 +12577,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12356,6 +12587,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12369,8 +12601,8 @@
       </note>
       <note dynamics="94.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12379,11 +12611,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12392,6 +12625,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -12399,8 +12633,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12426,7 +12660,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12440,8 +12674,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12450,6 +12684,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12466,7 +12701,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12475,11 +12710,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12488,8 +12724,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12497,8 +12733,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12506,11 +12742,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12519,8 +12756,8 @@
       </note>
       <note dynamics="90.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12529,18 +12766,19 @@
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12550,8 +12788,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12566,18 +12804,19 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12586,7 +12825,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12597,8 +12836,64 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12610,60 +12905,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12690,8 +12932,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12700,6 +12942,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12708,7 +12951,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12734,8 +12977,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12744,6 +12987,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12763,8 +13007,8 @@
     <measure implicit="no" number="59">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12789,8 +13033,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12803,8 +13047,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12813,6 +13057,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12826,7 +13071,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12843,8 +13088,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12853,11 +13098,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12883,8 +13129,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12896,8 +13142,8 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12906,6 +13152,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -12923,7 +13170,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12932,11 +13179,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12945,8 +13193,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12954,8 +13212,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12963,20 +13221,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12985,7 +13235,7 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13011,8 +13261,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13021,12 +13271,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13043,8 +13294,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13057,8 +13308,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13067,13 +13318,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 60 =========================-->
     <measure implicit="no" number="60">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13082,11 +13334,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13095,7 +13348,7 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13108,8 +13361,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13117,20 +13380,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13139,8 +13394,8 @@
       </note>
       <note dynamics="90.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13152,18 +13407,19 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13172,11 +13428,12 @@
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -13187,8 +13444,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13198,15 +13455,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13217,11 +13474,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13230,8 +13488,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13239,17 +13497,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13264,11 +13523,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13277,7 +13537,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13286,33 +13546,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13321,7 +13560,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13330,11 +13569,35 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13343,18 +13606,19 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13364,19 +13628,20 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -13385,8 +13650,8 @@
     <measure implicit="no" number="62">
       <note dynamics="84.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13411,7 +13676,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13426,8 +13691,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13436,6 +13701,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13452,8 +13718,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13461,17 +13727,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13483,8 +13750,8 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13493,6 +13760,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -13514,7 +13782,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13540,8 +13808,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13550,6 +13818,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13563,7 +13832,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13580,8 +13849,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13590,6 +13859,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13615,8 +13885,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13632,8 +13902,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13642,12 +13912,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13684,8 +13955,8 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13694,12 +13965,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13716,8 +13988,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13729,18 +14001,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13775,7 +14048,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13792,8 +14065,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13802,6 +14075,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13810,8 +14084,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13819,8 +14093,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13828,11 +14102,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13841,18 +14116,19 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13862,24 +14138,25 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13890,11 +14167,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13911,7 +14189,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13937,8 +14215,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13947,6 +14225,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -13960,8 +14239,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13970,6 +14249,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -13977,8 +14257,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13991,8 +14271,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14005,8 +14285,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14015,6 +14295,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14023,7 +14304,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14034,16 +14315,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14053,8 +14335,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14066,11 +14348,12 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14079,7 +14362,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14088,17 +14371,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14110,8 +14394,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14119,8 +14403,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14128,11 +14412,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14144,7 +14429,7 @@
     <measure implicit="no" number="65">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14153,11 +14438,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14166,8 +14452,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14177,35 +14463,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="103.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14231,8 +14519,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14244,7 +14532,7 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14271,8 +14559,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14280,8 +14568,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14289,11 +14577,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14302,37 +14591,39 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="103.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14357,8 +14648,8 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14367,6 +14658,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -14387,7 +14679,7 @@
     <measure implicit="no" number="66">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14413,8 +14705,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14423,6 +14715,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14436,8 +14729,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14453,8 +14746,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14467,8 +14760,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14477,6 +14770,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14485,7 +14779,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14494,11 +14788,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14507,7 +14802,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14516,20 +14820,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14538,8 +14834,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14547,17 +14853,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14573,18 +14870,19 @@
     <measure implicit="no" number="67">
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14594,19 +14892,20 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -14617,7 +14916,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14626,11 +14925,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14639,8 +14939,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14665,8 +14965,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14675,6 +14975,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14688,8 +14989,8 @@
       </note>
       <note dynamics="92.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14698,6 +14999,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -14709,7 +15011,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14718,11 +15020,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14731,7 +15034,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14740,11 +15043,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 68 =========================-->
@@ -14756,8 +15060,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14767,25 +15071,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="103.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14799,18 +15104,19 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14820,16 +15126,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14838,6 +15144,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -14860,7 +15167,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14886,8 +15193,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14896,6 +15203,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14912,8 +15220,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14921,8 +15229,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14930,11 +15238,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -14943,19 +15252,20 @@
       </note>
       <note dynamics="105.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 69 =========================-->
     <measure implicit="no" number="69">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14981,8 +15291,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14994,7 +15304,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15009,8 +15319,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15019,6 +15329,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15035,8 +15346,8 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15045,6 +15356,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15070,8 +15382,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15087,8 +15399,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15101,8 +15413,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15111,6 +15423,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15136,8 +15449,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15151,8 +15464,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15165,8 +15478,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15175,10 +15488,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15195,18 +15509,19 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15216,27 +15531,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15244,8 +15560,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15265,7 +15581,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15274,8 +15590,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15283,8 +15599,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15297,7 +15613,7 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15307,7 +15623,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15318,8 +15634,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15327,11 +15643,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15340,8 +15657,8 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15350,6 +15667,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -15375,8 +15693,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15385,6 +15703,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -15392,8 +15711,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15410,8 +15729,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15419,16 +15748,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15444,17 +15764,18 @@
     <measure implicit="no" number="71">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15466,7 +15787,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15475,20 +15805,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15497,8 +15819,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15506,17 +15838,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15528,7 +15851,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15537,11 +15860,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15550,7 +15874,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15559,11 +15883,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15572,17 +15897,18 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15595,8 +15921,8 @@
     <measure implicit="no" number="72">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15621,8 +15947,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15635,8 +15961,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15645,6 +15971,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15658,8 +15985,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15675,8 +16002,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15685,11 +16012,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15724,8 +16052,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15738,8 +16066,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15748,6 +16076,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -15764,8 +16093,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15790,7 +16119,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15813,8 +16142,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15830,8 +16159,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15840,12 +16169,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15879,7 +16209,7 @@
       </note>
       <note dynamics="83.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15908,7 +16238,7 @@
     <measure implicit="no" number="73">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15934,8 +16264,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15944,6 +16274,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15957,8 +16288,8 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15967,13 +16298,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15999,8 +16331,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16014,8 +16346,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16024,6 +16356,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16040,7 +16373,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16066,8 +16399,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16076,6 +16409,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16089,8 +16423,8 @@
       </note>
       <note dynamics="103.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16099,14 +16433,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16116,15 +16451,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16135,11 +16470,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16151,8 +16487,8 @@
     <measure implicit="no" number="74">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16160,11 +16496,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16173,7 +16510,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16182,11 +16519,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16195,8 +16533,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16206,15 +16544,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16225,16 +16564,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16244,8 +16584,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16257,17 +16597,18 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16277,8 +16618,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16288,8 +16629,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16301,7 +16642,7 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16311,8 +16652,8 @@
       </note>
       <note dynamics="74.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16321,11 +16662,12 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -16339,8 +16681,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16350,15 +16692,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16369,11 +16711,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16382,18 +16725,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16402,8 +16746,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16411,27 +16755,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16439,11 +16784,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16452,16 +16798,17 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16469,8 +16816,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16482,7 +16829,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16491,20 +16838,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16513,11 +16862,12 @@
       </note>
       <note dynamics="105.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16526,7 +16876,7 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16536,8 +16886,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16547,19 +16897,20 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 76 =========================-->
     <measure implicit="no" number="76">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -16584,8 +16935,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -16594,6 +16945,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16632,8 +16984,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16642,6 +16994,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -16649,7 +17002,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16685,20 +17038,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16707,8 +17062,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16718,24 +17073,25 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16767,7 +17123,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16793,8 +17149,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16803,12 +17159,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16830,7 +17187,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16848,8 +17205,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16858,11 +17215,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="86.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16887,7 +17245,7 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16907,8 +17265,8 @@
     <measure implicit="no" number="77">
       <note dynamics="84.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16933,8 +17291,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16943,11 +17301,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16964,8 +17323,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16990,8 +17349,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17000,6 +17359,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17013,8 +17373,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17023,6 +17383,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -17030,8 +17391,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17040,11 +17401,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17062,8 +17424,8 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17072,6 +17434,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -17097,8 +17460,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17111,8 +17474,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17124,7 +17487,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17141,8 +17504,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17151,6 +17514,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17176,8 +17540,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17193,8 +17557,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17203,6 +17567,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 78 =========================-->
@@ -17214,7 +17579,7 @@
       </note>
       <note dynamics="90.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17227,7 +17592,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17253,8 +17618,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17263,6 +17628,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17276,8 +17642,8 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17286,13 +17652,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17302,8 +17669,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17313,8 +17680,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17326,7 +17693,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17352,8 +17719,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17375,8 +17742,8 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17385,6 +17752,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -17399,7 +17767,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17408,11 +17776,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17421,8 +17790,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17430,8 +17799,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17439,11 +17808,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17452,7 +17822,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17461,11 +17831,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17474,7 +17845,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17483,20 +17863,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17510,7 +17882,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17519,11 +17891,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17541,7 +17914,7 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17559,7 +17932,7 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17572,11 +17945,12 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17585,25 +17959,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17619,11 +17995,12 @@
     <measure implicit="no" number="81">
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17632,8 +18009,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17641,11 +18018,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17654,42 +18032,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17698,7 +18056,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17707,11 +18065,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17720,7 +18079,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17729,8 +18088,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17738,11 +18111,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17754,11 +18137,12 @@
     <measure implicit="no" number="82">
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17767,7 +18151,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17794,8 +18178,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17804,6 +18188,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17812,7 +18197,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17838,8 +18223,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17848,6 +18233,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17864,8 +18250,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17873,8 +18259,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17882,11 +18268,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17895,7 +18282,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17922,8 +18309,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17932,6 +18319,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17940,7 +18328,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17966,8 +18354,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17976,6 +18364,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -17995,7 +18384,7 @@
     <measure implicit="no" number="83">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18021,8 +18410,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18031,6 +18420,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18044,8 +18434,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18061,8 +18451,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18071,6 +18461,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18096,8 +18487,8 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18106,6 +18497,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18122,7 +18514,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18148,8 +18540,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18158,6 +18550,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18171,7 +18564,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18188,8 +18581,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18198,6 +18591,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18223,8 +18617,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18237,8 +18631,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18251,8 +18645,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18261,6 +18655,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18280,7 +18675,7 @@
     <measure implicit="no" number="84">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18306,8 +18701,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18316,6 +18711,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18329,7 +18725,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18346,8 +18742,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18356,6 +18752,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18381,7 +18778,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18395,8 +18792,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18405,6 +18802,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18421,8 +18819,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18447,8 +18845,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18457,6 +18855,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18470,8 +18869,8 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18480,6 +18879,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -18491,7 +18891,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18500,11 +18900,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18516,7 +18917,7 @@
     <measure implicit="no" number="85">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18525,11 +18926,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18538,8 +18940,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18547,11 +18949,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18560,11 +18963,12 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18573,7 +18977,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18582,11 +18986,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18595,7 +19000,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18604,11 +19009,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18617,8 +19023,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18626,11 +19032,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18642,11 +19049,12 @@
     <measure implicit="no" number="86">
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18655,7 +19063,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18664,11 +19072,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18677,7 +19086,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18686,11 +19095,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18699,8 +19109,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18708,11 +19118,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18721,11 +19132,12 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18734,7 +19146,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18743,11 +19155,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18756,7 +19169,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18765,11 +19178,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 87 =========================-->
@@ -18781,8 +19195,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18790,11 +19204,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18803,7 +19218,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18812,11 +19227,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18825,7 +19241,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18834,11 +19250,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18847,7 +19264,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18856,11 +19273,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18869,8 +19287,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18878,11 +19296,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18891,11 +19310,12 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 88 =========================-->
@@ -18907,7 +19327,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18916,11 +19336,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18929,7 +19350,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18938,33 +19359,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -18973,8 +19373,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18982,33 +19382,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19017,7 +19396,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19026,18 +19405,65 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 89 =========================-->
     <measure implicit="no" number="89">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -19063,8 +19489,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -19073,6 +19499,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19111,8 +19538,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19128,8 +19555,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19138,6 +19565,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19164,11 +19592,12 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19177,7 +19606,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19204,8 +19633,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19214,6 +19643,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19222,7 +19652,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19248,8 +19678,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19258,6 +19688,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19274,8 +19705,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19283,17 +19714,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19305,7 +19737,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19314,18 +19746,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 90 =========================-->
     <measure implicit="no" number="90">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -19351,8 +19784,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -19361,6 +19794,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19399,7 +19833,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19416,8 +19850,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19426,6 +19860,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19451,7 +19886,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19465,8 +19900,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19475,6 +19910,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19491,8 +19927,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19517,7 +19953,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19531,8 +19981,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19541,20 +19991,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19568,7 +20005,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19585,8 +20022,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19595,6 +20032,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19620,7 +20058,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19634,8 +20072,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19644,6 +20082,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19660,7 +20099,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19687,8 +20126,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19697,6 +20136,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 91 =========================-->
@@ -19725,8 +20165,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19739,8 +20179,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19749,6 +20189,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19765,7 +20206,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19791,8 +20232,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19801,6 +20242,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19814,7 +20256,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19831,8 +20273,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19841,6 +20283,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19866,7 +20309,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19880,8 +20323,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19890,6 +20333,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19906,8 +20350,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19932,8 +20376,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19942,6 +20386,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19955,8 +20400,8 @@
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19965,6 +20410,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -19979,7 +20425,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19988,11 +20434,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20001,7 +20448,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20010,11 +20457,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20023,8 +20471,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20032,33 +20480,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20067,7 +20494,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20076,11 +20503,35 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20089,7 +20540,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20098,11 +20549,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20119,8 +20571,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20128,8 +20580,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20137,11 +20589,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20150,11 +20603,12 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20163,7 +20617,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20172,11 +20626,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20185,7 +20640,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20194,11 +20649,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20207,8 +20663,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20216,8 +20672,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20225,11 +20681,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20238,11 +20695,12 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20254,7 +20712,7 @@
     <measure implicit="no" number="94">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20263,11 +20721,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20276,7 +20735,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20285,11 +20744,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20298,8 +20758,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20307,11 +20767,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20320,7 +20781,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20329,11 +20790,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20342,7 +20804,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20369,8 +20831,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20379,6 +20841,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20387,7 +20850,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20413,8 +20876,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20423,6 +20886,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20442,8 +20906,8 @@
     <measure implicit="no" number="95">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20451,11 +20915,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20464,8 +20929,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20474,6 +20939,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -20491,8 +20957,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20501,6 +20967,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20509,7 +20976,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20535,8 +21002,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20545,6 +21012,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20558,7 +21026,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20575,8 +21043,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20585,6 +21053,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20610,8 +21079,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20624,8 +21093,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20638,8 +21107,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20648,6 +21117,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20664,8 +21134,8 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20674,6 +21144,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -20705,7 +21176,7 @@
     <measure implicit="no" number="96">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20731,8 +21202,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20741,6 +21212,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20754,7 +21226,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20771,8 +21243,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20781,6 +21253,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20789,8 +21262,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20798,8 +21271,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20807,55 +21280,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20864,7 +21294,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20873,11 +21303,58 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20889,8 +21366,8 @@
     <measure implicit="no" number="97">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20898,8 +21375,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20907,11 +21384,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20920,11 +21398,12 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20933,7 +21412,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20942,11 +21421,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20955,7 +21435,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20964,11 +21444,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20977,8 +21458,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20986,8 +21467,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20995,11 +21476,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21008,11 +21490,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21021,7 +21504,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21030,11 +21513,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 98 =========================-->
@@ -21046,7 +21530,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21055,11 +21539,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21068,8 +21553,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21077,8 +21562,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21086,11 +21571,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21099,11 +21585,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21112,7 +21599,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21121,11 +21608,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21134,7 +21622,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21143,11 +21631,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21156,8 +21645,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21165,8 +21654,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21174,11 +21663,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 99 =========================-->
@@ -21190,11 +21680,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21203,7 +21694,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21212,11 +21703,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21225,7 +21717,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21252,8 +21744,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21262,6 +21754,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21270,8 +21763,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21296,8 +21789,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21310,8 +21803,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21320,6 +21813,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21333,7 +21827,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21350,8 +21844,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21360,6 +21854,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21385,7 +21880,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21402,8 +21897,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21412,6 +21907,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--======================== Measure 100 =========================-->
@@ -21440,7 +21936,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21454,8 +21950,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21464,6 +21960,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21480,8 +21977,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21506,8 +22003,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21520,8 +22017,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21530,6 +22027,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21543,8 +22041,8 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21553,6 +22051,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -21581,7 +22080,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21595,8 +22094,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21605,6 +22104,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21621,7 +22121,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21630,11 +22130,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21643,7 +22144,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21652,8 +22153,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21673,7 +22174,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21682,11 +22183,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21695,7 +22197,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21704,11 +22206,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21717,7 +22220,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21730,8 +22233,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21739,7 +22242,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21752,8 +22255,8 @@
       </note>
       <note dynamics="141.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21765,7 +22268,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21774,11 +22277,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21816,8 +22320,8 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21826,6 +22330,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -21884,8 +22389,8 @@
       </note>
       <note dynamics="106.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21894,6 +22399,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -21905,8 +22411,8 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21915,8 +22421,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21926,11 +22432,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21939,8 +22446,8 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21949,18 +22456,19 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21969,11 +22477,12 @@
       </note>
       <note dynamics="105.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21982,8 +22491,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21993,25 +22502,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22021,19 +22531,20 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 107 =========================-->
     <measure implicit="no" number="107">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22059,8 +22570,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22069,11 +22580,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22087,8 +22599,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22097,11 +22609,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22118,8 +22631,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22131,7 +22644,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22157,8 +22670,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22167,6 +22680,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22180,8 +22694,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22197,8 +22711,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22232,8 +22746,8 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22242,11 +22756,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22264,8 +22779,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22277,8 +22792,8 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22287,6 +22802,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -22303,8 +22819,8 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22317,7 +22833,7 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22359,8 +22875,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22373,8 +22889,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22383,12 +22899,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22435,7 +22952,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22452,8 +22969,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22462,6 +22979,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22470,7 +22988,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22479,11 +22997,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22492,8 +23011,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22505,11 +23024,12 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22526,11 +23046,12 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22539,7 +23060,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22548,11 +23069,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22561,8 +23083,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22570,11 +23092,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22583,11 +23106,12 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22596,7 +23120,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22605,11 +23129,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22618,7 +23143,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22627,11 +23152,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22643,8 +23169,8 @@
     <measure implicit="no" number="110">
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22656,16 +23182,17 @@
       </note>
       <note dynamics="105.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22690,8 +23217,8 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22700,12 +23227,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22722,8 +23250,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22735,7 +23263,7 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22770,8 +23298,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22787,8 +23315,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22797,12 +23325,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22836,8 +23365,8 @@
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22846,6 +23375,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22865,7 +23395,7 @@
     <measure implicit="no" number="111">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22874,11 +23404,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22887,7 +23418,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22896,11 +23427,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22909,8 +23441,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22918,17 +23450,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22940,11 +23473,12 @@
       </note>
       <note dynamics="106.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22953,8 +23487,8 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22963,18 +23497,19 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22984,15 +23519,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23001,11 +23536,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23014,8 +23550,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23023,8 +23559,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23034,7 +23570,7 @@
     <measure implicit="no" number="112">
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23047,17 +23583,18 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23067,7 +23604,7 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23102,7 +23639,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23119,8 +23656,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23129,6 +23666,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23154,8 +23692,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23168,8 +23706,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23178,6 +23716,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23194,18 +23733,19 @@
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note dynamics="92.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23240,8 +23780,8 @@
       </note>
       <note dynamics="105.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23250,6 +23790,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -23264,7 +23805,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23273,11 +23814,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23286,8 +23828,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23295,17 +23837,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23317,7 +23860,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23326,11 +23869,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23339,7 +23883,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23348,11 +23892,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23361,8 +23906,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23370,11 +23915,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23391,18 +23937,19 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23412,16 +23959,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23431,16 +23978,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23452,7 +24000,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23461,11 +24009,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23474,8 +24023,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23483,17 +24032,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23505,8 +24055,8 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23515,6 +24065,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -23536,7 +24087,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23562,8 +24113,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23572,6 +24123,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23591,7 +24143,7 @@
     <measure implicit="no" number="115">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23617,8 +24169,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23627,6 +24179,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23640,8 +24193,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23657,8 +24210,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23671,8 +24224,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23681,6 +24234,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23706,7 +24260,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23721,8 +24275,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23731,11 +24285,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23752,8 +24307,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23765,11 +24320,12 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23778,7 +24334,7 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23791,8 +24347,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23800,17 +24356,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23825,11 +24382,12 @@
     <measure implicit="no" number="116">
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23838,7 +24396,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23847,11 +24405,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23860,7 +24419,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23869,11 +24428,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23882,8 +24442,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23891,8 +24451,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23900,11 +24460,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23913,18 +24474,19 @@
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23934,19 +24496,20 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -23955,8 +24518,8 @@
       </note>
       <note dynamics="85.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23965,7 +24528,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23976,18 +24539,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--======================== Measure 117 =========================-->
     <measure implicit="no" number="117">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -24013,8 +24577,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -24023,6 +24587,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24061,8 +24626,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24078,8 +24643,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24092,8 +24657,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24102,6 +24667,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24127,8 +24693,8 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24137,12 +24703,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24159,8 +24726,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24172,8 +24739,8 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24182,6 +24749,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
@@ -24199,8 +24767,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24210,8 +24778,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24219,15 +24787,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24238,11 +24807,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24251,8 +24821,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24277,8 +24847,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24300,8 +24870,8 @@
       </note>
       <note dynamics="94.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24310,6 +24880,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -24319,8 +24890,8 @@
     <measure implicit="no" number="118">
       <note dynamics="84.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24329,11 +24900,12 @@
       </note>
       <note dynamics="98.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -24344,7 +24916,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24353,11 +24925,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24366,8 +24939,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24375,17 +24948,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24397,7 +24971,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24406,11 +24980,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24419,7 +24994,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24428,11 +25003,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24444,8 +25020,8 @@
     <measure implicit="no" number="119">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24470,8 +25046,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24480,6 +25056,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24493,7 +25070,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24510,8 +25087,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24520,6 +25097,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24545,8 +25123,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24555,6 +25133,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24571,7 +25150,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24597,8 +25176,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24607,6 +25186,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24620,8 +25200,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24637,8 +25217,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24672,8 +25252,8 @@
       </note>
       <note dynamics="90.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24682,6 +25262,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24701,7 +25282,7 @@
     <measure implicit="no" number="120">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24710,11 +25291,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24723,7 +25305,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24732,11 +25314,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24745,8 +25328,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24754,8 +25337,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24763,11 +25346,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24776,11 +25360,12 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24789,7 +25374,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24802,8 +25387,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24811,8 +25396,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24820,11 +25405,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--======================== Measure 121 =========================-->
@@ -24836,11 +25422,12 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24849,7 +25436,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24858,11 +25445,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24871,7 +25459,7 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24902,8 +25490,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24928,8 +25516,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24942,8 +25530,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24952,6 +25540,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24968,16 +25557,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24985,8 +25575,8 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24995,6 +25585,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -25011,8 +25602,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25026,8 +25617,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25052,12 +25643,13 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tied type="start" />
         </notations>
@@ -25067,8 +25659,8 @@
     <measure implicit="no" number="122">
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -25078,6 +25670,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tied type="stop" />
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -25129,7 +25722,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25146,8 +25739,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25160,8 +25753,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25170,6 +25763,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25196,7 +25790,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25205,17 +25808,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25227,7 +25821,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25236,8 +25830,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25245,8 +25839,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25258,7 +25852,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25267,11 +25861,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25280,7 +25875,7 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25293,8 +25888,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25309,7 +25904,7 @@
     <measure implicit="no" number="123">
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25323,11 +25918,12 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25336,7 +25932,7 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25349,8 +25945,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25358,11 +25954,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25371,11 +25968,12 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25384,7 +25982,7 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25400,7 +25998,7 @@
     <measure implicit="no" number="124">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25426,8 +26024,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25436,6 +26034,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25449,8 +26048,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25466,8 +26065,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25501,8 +26100,8 @@
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25511,6 +26110,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25527,8 +26127,8 @@
       </note>
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25537,6 +26137,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -25562,7 +26163,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25579,8 +26180,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25589,6 +26190,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25597,8 +26199,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25606,17 +26208,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25631,8 +26234,8 @@
     <measure implicit="no" number="125">
       <note dynamics="95.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25641,6 +26244,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -25657,8 +26261,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25672,7 +26276,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25686,8 +26290,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25696,6 +26300,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25717,7 +26322,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25726,11 +26331,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25739,17 +26345,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25761,7 +26368,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25770,11 +26377,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25783,11 +26391,12 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25796,7 +26405,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25805,11 +26414,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--======================== Measure 126 =========================-->
@@ -25821,8 +26431,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25830,8 +26440,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25839,11 +26449,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25852,11 +26463,12 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25865,7 +26477,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25892,8 +26504,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25902,6 +26514,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25910,7 +26523,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25936,8 +26549,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25946,6 +26559,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25959,8 +26573,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25976,8 +26590,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25990,8 +26604,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26000,6 +26614,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -26025,8 +26640,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26042,8 +26657,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26058,7 +26673,7 @@
     <measure implicit="no" number="127">
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26084,8 +26699,8 @@
       </note>
       <note dynamics="106.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26094,12 +26709,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26116,8 +26732,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26129,7 +26745,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26138,11 +26754,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -26151,8 +26768,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26160,17 +26777,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26182,7 +26800,7 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>

--- a/public/transcription-samples/night-in-tunisia/adtof-drums/ADTfa88d256e0ac_drum_transcription.musicxml
+++ b/public/transcription-samples/night-in-tunisia/adtof-drums/ADTfa88d256e0ac_drum_transcription.musicxml
@@ -5,7 +5,7 @@
   <identification>
     <creator type="composer">Music21</creator>
     <encoding>
-      <encoding-date>2026-07-03</encoding-date>
+      <encoding-date>2026-07-05</encoding-date>
       <software>music21 v.10.5.0</software>
       <supports element="beam" type="yes" />
       <supports element="stem" type="yes" />
@@ -19,21 +19,21 @@
     </scaling>
   </defaults>
   <part-list>
-    <score-part id="P78c75827c3cc8bc4dc3786737a66847b">
+    <score-part id="P0c6771c48087a8339d70f16cc1dde5a0">
       <part-name>Percussion</part-name>
       <part-abbreviation>Perc</part-abbreviation>
-      <score-instrument id="Ia2e19235ae84bbdf9daaf89241b81efd">
+      <score-instrument id="I44e73f4b75f4bce7f4a21298ede943c3">
         <instrument-name>Percussion</instrument-name>
         <instrument-abbreviation>Perc</instrument-abbreviation>
       </score-instrument>
-      <midi-instrument id="Ia2e19235ae84bbdf9daaf89241b81efd">
+      <midi-instrument id="I44e73f4b75f4bce7f4a21298ede943c3">
         <midi-channel>10</midi-channel>
         <midi-program>2</midi-program>
       </midi-instrument>
     </score-part>
   </part-list>
   <!--=========================== Part 1 ===========================-->
-  <part id="P78c75827c3cc8bc4dc3786737a66847b">
+  <part id="P0c6771c48087a8339d70f16cc1dde5a0">
     <!--========================= Measure 1 ==========================-->
     <measure implicit="no" number="1">
       <attributes>
@@ -43,8 +43,7 @@
           <beat-type>4</beat-type>
         </time>
         <clef>
-          <sign>G</sign>
-          <line>2</line>
+          <sign>percussion</sign>
         </clef>
       </attributes>
       <direction>
@@ -97,8 +96,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -122,7 +121,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -132,12 +131,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -147,19 +147,20 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -168,8 +169,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -180,12 +181,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -195,7 +197,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -211,8 +213,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -222,12 +224,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -237,15 +240,17 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">backward hook</beam>
       </note>
@@ -262,7 +267,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -272,22 +287,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -297,8 +303,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -308,7 +314,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -320,8 +326,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -330,12 +336,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -360,7 +367,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -370,8 +377,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
@@ -394,7 +401,7 @@
     <measure implicit="no" number="6">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -421,8 +428,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -431,12 +438,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -448,8 +456,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -458,13 +466,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -489,7 +498,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -498,25 +507,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -541,7 +551,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -556,8 +566,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -570,8 +580,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -580,11 +590,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -601,7 +612,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -615,8 +626,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -625,6 +636,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -633,16 +645,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -655,7 +668,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -664,25 +686,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -694,7 +708,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -705,16 +719,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -724,8 +738,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -741,8 +755,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -753,8 +767,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -762,8 +776,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -779,8 +793,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -790,7 +804,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -806,8 +820,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -821,8 +835,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -832,6 +846,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -846,7 +861,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -861,8 +891,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -872,26 +902,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -906,8 +922,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -917,10 +933,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -936,8 +953,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -947,11 +964,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -966,7 +984,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -981,8 +999,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -992,11 +1010,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -1010,7 +1029,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1026,8 +1045,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -1041,8 +1060,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -1052,6 +1071,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1080,7 +1100,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1095,8 +1115,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -1106,12 +1126,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -1134,7 +1155,7 @@
     <measure implicit="no" number="8">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1145,43 +1166,45 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1192,17 +1215,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1214,7 +1238,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1240,8 +1264,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1254,8 +1278,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1264,6 +1288,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1277,7 +1302,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1294,8 +1319,23 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1306,22 +1346,18 @@
         </time-modification>
       </note>
       <note>
-        <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
+        <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1330,20 +1366,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1352,7 +1380,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1361,20 +1398,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1383,8 +1412,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1394,16 +1423,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1412,8 +1441,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1423,16 +1452,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1442,8 +1471,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1458,8 +1487,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1469,15 +1498,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1488,25 +1517,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1515,7 +1545,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1524,8 +1554,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1537,7 +1567,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1546,17 +1576,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1568,8 +1599,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1578,6 +1609,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -1595,7 +1627,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1608,8 +1640,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1623,7 +1655,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1637,8 +1669,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1647,6 +1679,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1663,8 +1696,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1672,8 +1705,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1685,7 +1718,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1696,8 +1729,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1705,16 +1738,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1724,7 +1758,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1733,11 +1767,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1749,8 +1784,8 @@
     <measure implicit="no" number="10">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -1759,12 +1794,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1774,7 +1810,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1784,12 +1820,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1799,7 +1836,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1815,8 +1852,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -1830,8 +1867,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -1841,11 +1878,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -1866,8 +1904,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -1877,12 +1915,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1896,8 +1935,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -1912,7 +1951,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1927,8 +1966,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -1938,6 +1977,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1952,8 +1992,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -1962,8 +2002,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -1971,7 +2011,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1986,8 +2026,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -2011,8 +2051,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -2026,8 +2066,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -2050,7 +2090,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2060,18 +2100,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
@@ -2094,8 +2135,8 @@
     <measure implicit="no" number="11">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2121,8 +2162,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2134,7 +2175,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2149,8 +2190,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2159,12 +2200,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2189,15 +2231,15 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2208,16 +2250,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2226,18 +2268,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2250,7 +2293,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2263,7 +2306,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2274,25 +2317,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2302,7 +2346,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2315,8 +2359,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2341,8 +2385,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2364,8 +2408,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2381,8 +2425,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2397,8 +2441,8 @@
     <measure implicit="no" number="12">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -2409,8 +2453,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -2418,7 +2462,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2430,17 +2474,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -2451,7 +2496,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2466,7 +2511,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2476,12 +2521,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2491,7 +2537,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2501,8 +2547,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -2522,7 +2568,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2538,8 +2584,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -2549,11 +2595,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -2585,7 +2632,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2595,8 +2642,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
@@ -2613,7 +2660,7 @@
     <measure implicit="no" number="13">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2622,7 +2669,31 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2635,30 +2706,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2684,7 +2733,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2698,8 +2747,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2708,11 +2757,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2725,7 +2775,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2743,8 +2793,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2756,8 +2806,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2783,7 +2833,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2797,8 +2847,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2807,11 +2857,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2825,8 +2876,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2835,6 +2886,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2851,7 +2903,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2860,25 +2921,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2903,7 +2956,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2918,8 +2971,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2947,7 +3000,7 @@
     <measure implicit="no" number="14">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2959,7 +3012,30 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2967,9 +3043,81 @@
         <type>16th</type>
       </note>
       <note>
+        <rest />
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -2980,8 +3128,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -2995,52 +3143,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3051,56 +3155,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3108,8 +3164,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3125,7 +3181,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3137,8 +3193,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3146,8 +3202,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3157,7 +3213,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3169,18 +3225,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3202,7 +3259,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3217,8 +3274,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -3228,12 +3285,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -3255,17 +3313,18 @@
     <measure implicit="no" number="15">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3280,7 +3339,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3290,18 +3349,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3315,8 +3375,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3330,7 +3390,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3340,12 +3400,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3355,20 +3416,21 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3376,7 +3438,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3388,12 +3450,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3403,7 +3466,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3413,12 +3476,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3428,8 +3492,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -3438,12 +3502,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <backup>
         <duration>40320</duration>
@@ -3461,7 +3526,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3476,8 +3541,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -3491,8 +3556,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -3502,6 +3567,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3525,7 +3591,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3536,26 +3602,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3568,8 +3636,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3579,24 +3647,25 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3607,35 +3676,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3648,17 +3719,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3669,17 +3741,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3694,20 +3767,22 @@
     <measure implicit="no" number="17">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3716,37 +3791,40 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3755,6 +3833,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -3771,7 +3850,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3786,8 +3865,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3799,8 +3878,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3809,6 +3888,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -3817,7 +3897,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3830,8 +3910,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3857,8 +3937,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3867,10 +3947,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3885,8 +3966,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3895,12 +3976,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3922,8 +4004,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3932,6 +4014,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -3939,7 +4022,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3957,7 +4040,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3984,8 +4067,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3994,12 +4077,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4011,8 +4095,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4021,6 +4105,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -4029,7 +4114,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4045,8 +4130,8 @@
     <measure implicit="no" number="18">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4072,8 +4157,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4082,12 +4167,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4099,7 +4185,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4114,8 +4200,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4124,6 +4210,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4140,15 +4227,16 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4157,11 +4245,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4170,18 +4259,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4189,8 +4279,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4200,11 +4290,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4213,7 +4304,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4224,35 +4315,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4260,11 +4353,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -4275,7 +4369,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4286,35 +4380,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4322,8 +4418,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4333,17 +4429,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4358,7 +4455,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4369,43 +4466,45 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4416,17 +4515,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4438,18 +4538,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4457,8 +4558,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4468,11 +4569,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4481,11 +4583,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4495,8 +4598,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4505,6 +4608,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -4521,8 +4625,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4535,8 +4639,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4555,7 +4659,7 @@
     <measure implicit="no" number="20">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4564,8 +4668,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4577,7 +4681,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4586,8 +4690,32 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4595,8 +4723,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4608,8 +4736,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4617,8 +4745,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4630,7 +4758,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4639,21 +4767,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
+        <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4661,29 +4786,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4692,7 +4800,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4701,11 +4809,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4714,7 +4823,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4723,20 +4841,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4748,7 +4858,7 @@
     <measure implicit="no" number="21">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4757,16 +4867,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4779,7 +4890,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4788,8 +4899,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4801,17 +4912,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4823,7 +4935,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4832,16 +4944,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4849,7 +4962,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4875,7 +4988,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4890,8 +5003,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4904,8 +5017,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4914,6 +5027,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4930,7 +5044,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4939,16 +5053,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4973,7 +5087,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4988,8 +5102,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5017,8 +5131,8 @@
     <measure implicit="no" number="22">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5030,8 +5144,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5039,8 +5153,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5052,8 +5166,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5063,16 +5177,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5081,7 +5195,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5092,11 +5206,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5105,7 +5220,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5114,11 +5229,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5127,7 +5243,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5153,8 +5269,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5163,12 +5279,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5190,7 +5307,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5207,8 +5324,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5217,12 +5334,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5242,7 +5360,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5253,26 +5371,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5285,8 +5405,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5312,7 +5432,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5326,8 +5446,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5336,11 +5456,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5353,7 +5474,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5371,8 +5492,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5389,7 +5510,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5399,8 +5520,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5410,8 +5531,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5423,7 +5544,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5434,25 +5555,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5461,6 +5583,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5478,7 +5601,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5501,8 +5624,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5518,8 +5641,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5528,13 +5651,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 24 =========================-->
     <measure implicit="no" number="24">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5561,8 +5685,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5574,8 +5698,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5584,12 +5708,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5615,7 +5740,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5626,25 +5751,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5653,6 +5779,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5670,7 +5797,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5693,8 +5820,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5707,8 +5834,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5717,12 +5844,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5734,7 +5862,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5751,8 +5879,109 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+        <beam number="1">continue</beam>
+        <notations>
+          <tuplet bracket="yes" number="1" placement="above" type="start">
+            <tuplet-actual>
+              <tuplet-number>3</tuplet-number>
+              <tuplet-type>eighth</tuplet-type>
+            </tuplet-actual>
+            <tuplet-normal>
+              <tuplet-number>2</tuplet-number>
+              <tuplet-type>eighth</tuplet-type>
+            </tuplet-normal>
+          </tuplet>
+        </notations>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <beam number="1">end</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet number="1" type="stop" />
+        </notations>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5778,8 +6007,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5788,26 +6017,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <beam number="1">end</beam>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5819,92 +6035,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <beam number="1">begin</beam>
-        <notations>
-          <tuplet number="1" type="stop" />
-        </notations>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-        <beam number="1">continue</beam>
-        <notations>
-          <tuplet bracket="yes" number="1" placement="above" type="start">
-            <tuplet-actual>
-              <tuplet-number>3</tuplet-number>
-              <tuplet-type>eighth</tuplet-type>
-            </tuplet-actual>
-            <tuplet-normal>
-              <tuplet-number>2</tuplet-number>
-              <tuplet-type>eighth</tuplet-type>
-            </tuplet-normal>
-          </tuplet>
-        </notations>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5922,8 +6053,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5932,23 +6063,25 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 25 =========================-->
     <measure implicit="no" number="25">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5963,7 +6096,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5973,22 +6116,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5998,7 +6132,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6013,8 +6147,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -6028,8 +6162,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -6039,6 +6173,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6053,8 +6188,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -6068,8 +6203,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -6082,8 +6217,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -6094,8 +6229,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -6103,8 +6238,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -6120,7 +6255,26 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6130,31 +6284,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6164,7 +6300,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6174,12 +6310,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6203,7 +6340,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6218,8 +6355,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -6229,6 +6366,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6252,8 +6390,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6261,8 +6399,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6274,7 +6412,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6300,8 +6438,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6310,6 +6448,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6323,7 +6462,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6340,8 +6479,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6350,6 +6489,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6358,7 +6498,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6368,8 +6508,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6379,11 +6519,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6392,7 +6533,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6401,11 +6542,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6414,7 +6556,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6423,11 +6565,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 27 =========================-->
@@ -6439,7 +6582,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6474,8 +6617,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6484,11 +6627,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6504,7 +6648,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6518,8 +6662,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6528,6 +6672,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6553,8 +6698,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6567,7 +6712,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6580,8 +6725,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6598,8 +6743,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6608,10 +6753,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6637,8 +6783,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6647,12 +6793,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6678,7 +6825,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6704,8 +6851,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6714,6 +6861,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6733,7 +6881,7 @@
     <measure implicit="no" number="28">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6742,11 +6890,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6755,11 +6904,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6768,7 +6918,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6777,11 +6927,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6790,7 +6941,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6799,8 +6950,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6808,11 +6959,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6821,7 +6973,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6834,8 +6986,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6844,6 +6996,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6860,7 +7013,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6883,7 +7036,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6900,8 +7053,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6910,13 +7063,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 29 =========================-->
     <measure implicit="no" number="29">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6942,8 +7096,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6956,8 +7110,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6966,6 +7120,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6979,7 +7134,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6995,8 +7150,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7005,6 +7160,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -7030,7 +7186,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7047,8 +7203,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7057,6 +7213,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7082,8 +7239,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7092,6 +7249,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7108,8 +7266,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7117,11 +7275,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7130,11 +7289,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7146,7 +7306,7 @@
     <measure implicit="no" number="30">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7155,11 +7315,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7168,7 +7329,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7177,11 +7338,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7190,7 +7352,44 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7199,7 +7398,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7212,55 +7425,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7295,8 +7460,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7312,8 +7477,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7322,12 +7487,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7336,6 +7502,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 31 =========================-->
@@ -7347,18 +7514,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7366,8 +7534,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7377,8 +7545,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7390,7 +7558,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7401,7 +7569,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7409,8 +7577,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7420,7 +7588,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7429,11 +7597,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7442,8 +7611,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7451,11 +7620,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7464,26 +7634,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7494,25 +7666,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7521,7 +7694,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7548,8 +7721,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7558,12 +7731,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7572,11 +7746,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7590,7 +7765,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7604,8 +7779,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7614,6 +7789,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7630,8 +7806,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7639,11 +7815,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 32 =========================-->
@@ -7655,17 +7832,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7676,17 +7854,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7698,8 +7877,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7725,8 +7904,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7738,8 +7917,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7753,8 +7932,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7766,8 +7945,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7784,8 +7963,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7797,8 +7976,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7823,8 +8002,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7837,7 +8016,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7855,8 +8034,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7882,8 +8061,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7895,7 +8074,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7904,27 +8083,29 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 34 =========================-->
     <measure implicit="no" number="34">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -7950,8 +8131,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -7960,12 +8141,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -7974,6 +8156,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8012,7 +8195,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8029,8 +8212,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8039,6 +8222,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8065,7 +8249,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8075,18 +8259,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8099,7 +8284,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8110,16 +8295,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8128,6 +8314,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8145,7 +8332,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8159,8 +8346,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8169,6 +8356,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8182,8 +8370,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8192,10 +8380,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8213,8 +8402,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8226,8 +8415,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8253,8 +8442,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8266,7 +8455,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8284,8 +8473,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8294,6 +8483,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 35 =========================-->
@@ -8305,7 +8495,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8331,8 +8521,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8345,8 +8535,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8355,6 +8545,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8368,8 +8559,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8378,6 +8569,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -8385,7 +8577,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8398,16 +8590,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8420,7 +8613,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8429,33 +8622,35 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8468,8 +8663,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8479,15 +8674,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8498,19 +8694,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8519,7 +8717,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8530,25 +8728,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8560,7 +8759,7 @@
     <measure implicit="no" number="36">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8587,8 +8786,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8601,8 +8800,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8611,11 +8810,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8629,8 +8829,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8639,11 +8839,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8652,6 +8853,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -8660,8 +8862,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8670,6 +8872,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8678,26 +8881,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8708,17 +8912,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8730,18 +8935,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8749,8 +8955,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8776,8 +8982,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8786,6 +8992,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8799,7 +9006,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8816,8 +9023,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8826,12 +9033,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8843,17 +9051,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8864,11 +9073,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8880,7 +9090,7 @@
     <measure implicit="no" number="37">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8889,8 +9099,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8898,11 +9108,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8911,7 +9122,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8937,8 +9148,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8947,6 +9158,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8985,8 +9197,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9001,7 +9213,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9012,16 +9224,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9031,15 +9244,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9050,8 +9264,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9059,11 +9273,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9072,7 +9287,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9099,8 +9314,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9109,11 +9324,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9122,12 +9338,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9153,7 +9370,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9162,20 +9388,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 38 =========================-->
@@ -9187,8 +9405,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9197,7 +9415,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9208,8 +9426,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9221,8 +9439,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9230,8 +9448,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9243,8 +9461,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9254,15 +9472,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9273,25 +9491,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9300,7 +9519,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9311,8 +9530,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9320,11 +9539,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9333,7 +9553,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9342,20 +9562,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9364,7 +9586,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9374,8 +9596,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9385,7 +9607,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9394,11 +9616,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9410,8 +9633,8 @@
     <measure implicit="no" number="39">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -9421,7 +9644,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9437,8 +9660,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -9452,8 +9675,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -9463,6 +9686,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9477,8 +9701,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -9497,8 +9721,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <voice>1</voice>
@@ -9508,14 +9732,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <voice>1</voice>
@@ -9528,8 +9753,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <voice>1</voice>
@@ -9539,6 +9764,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
         <beam number="3">backward hook</beam>
@@ -9546,8 +9772,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <voice>1</voice>
@@ -9566,7 +9792,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9578,18 +9804,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -9597,19 +9824,20 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9624,8 +9852,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -9636,16 +9864,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9657,18 +9886,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -9676,19 +9906,20 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9703,20 +9934,21 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -9724,7 +9956,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9736,18 +9968,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -9771,7 +10004,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9781,18 +10014,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
@@ -9810,7 +10044,7 @@
     <measure implicit="no" number="40">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9819,7 +10053,30 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9828,8 +10085,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9841,57 +10108,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9902,16 +10139,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9925,7 +10163,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9934,11 +10172,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9947,7 +10186,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9956,11 +10195,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9970,8 +10210,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9981,16 +10221,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10007,8 +10247,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10020,7 +10260,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10029,11 +10269,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10042,8 +10283,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10055,7 +10296,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10082,8 +10323,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10095,8 +10336,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10112,8 +10353,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10128,8 +10369,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10155,7 +10396,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10169,8 +10410,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10179,14 +10420,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 42 =========================-->
     <measure implicit="no" number="42">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10198,8 +10440,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10208,7 +10450,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10219,8 +10461,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10232,8 +10474,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10242,8 +10484,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10253,11 +10495,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10266,11 +10509,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10279,7 +10523,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10290,7 +10534,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10299,16 +10543,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10318,11 +10563,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10331,7 +10577,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10342,16 +10588,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10361,7 +10608,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10370,11 +10617,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10386,8 +10634,8 @@
     <measure implicit="no" number="43">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10397,15 +10645,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10432,8 +10680,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10455,8 +10703,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10469,8 +10717,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10479,11 +10727,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10499,8 +10748,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10526,8 +10775,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10536,6 +10785,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10549,7 +10799,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -10565,8 +10815,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -10575,12 +10825,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -10589,10 +10840,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -10611,8 +10863,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -10621,12 +10873,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -10635,6 +10888,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10643,7 +10897,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10669,8 +10923,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10679,6 +10933,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10695,8 +10950,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10704,8 +10959,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10717,7 +10972,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10726,11 +10981,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10739,7 +10995,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10748,8 +11004,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10757,11 +11013,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 44 =========================-->
@@ -10773,7 +11030,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10784,26 +11041,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10812,8 +11071,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10825,8 +11084,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10852,7 +11111,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10866,8 +11125,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10876,11 +11135,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10906,7 +11166,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10915,7 +11175,34 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10924,37 +11211,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10963,8 +11225,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10974,16 +11236,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10993,7 +11256,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11002,16 +11265,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11019,8 +11283,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11032,7 +11296,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11041,8 +11305,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11050,11 +11314,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11066,7 +11331,7 @@
     <measure implicit="no" number="45">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11076,12 +11341,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11091,7 +11357,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11102,8 +11368,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11114,7 +11380,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11124,17 +11390,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11148,7 +11415,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11160,8 +11427,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11169,8 +11436,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11181,8 +11448,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11196,8 +11463,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11208,8 +11475,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11217,8 +11484,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11234,8 +11501,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11245,7 +11512,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11257,8 +11524,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11266,8 +11533,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -11297,7 +11564,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11312,8 +11579,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -11323,12 +11590,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -11352,7 +11620,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11367,8 +11635,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -11378,12 +11646,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -11399,16 +11668,17 @@
     <measure implicit="no" number="46">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11421,7 +11691,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11430,20 +11709,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11452,8 +11723,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11463,15 +11734,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11482,8 +11753,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11491,11 +11762,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11504,8 +11776,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11513,16 +11785,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11548,8 +11820,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11561,7 +11833,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11576,8 +11848,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11586,6 +11858,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11602,8 +11875,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11611,7 +11884,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11619,7 +11892,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11645,8 +11918,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11655,6 +11928,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11668,7 +11942,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11685,8 +11959,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11695,6 +11969,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 47 =========================-->
@@ -11707,15 +11982,15 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11741,8 +12016,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11751,6 +12026,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11764,7 +12040,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11780,8 +12056,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11789,7 +12065,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11802,8 +12078,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11811,11 +12087,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11824,7 +12101,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11833,20 +12119,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11855,7 +12133,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11870,7 +12148,7 @@
     <measure implicit="no" number="48">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -11932,7 +12210,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11950,8 +12228,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11960,10 +12238,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11990,8 +12269,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12000,11 +12279,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12040,7 +12320,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12049,8 +12329,64 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12062,60 +12398,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12141,8 +12424,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12151,12 +12434,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12178,7 +12462,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12195,8 +12479,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12205,12 +12489,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12231,8 +12516,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12240,16 +12525,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12275,8 +12560,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12288,8 +12573,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12303,8 +12588,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12316,7 +12601,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12334,8 +12619,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12344,6 +12629,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12352,7 +12638,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12387,7 +12673,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12408,7 +12694,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12421,7 +12707,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12430,17 +12716,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12455,7 +12742,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12466,19 +12753,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -12489,11 +12778,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12502,7 +12792,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12511,11 +12801,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12524,7 +12815,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12533,11 +12824,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12546,8 +12838,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12556,6 +12848,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12572,8 +12865,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12595,7 +12888,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12612,8 +12905,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12622,14 +12915,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 51 =========================-->
     <measure implicit="no" number="51">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12654,7 +12948,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12668,8 +12962,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12678,6 +12972,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12691,7 +12986,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12708,8 +13003,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12718,6 +13013,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12726,7 +13022,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12735,8 +13031,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12744,11 +13040,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12757,8 +13054,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12783,7 +13080,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12798,8 +13095,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12808,6 +13105,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12824,7 +13122,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12837,7 +13135,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12848,27 +13146,29 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12878,8 +13178,8 @@
     <measure implicit="no" number="52">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -12888,6 +13188,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12904,8 +13205,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -12952,8 +13253,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12970,7 +13271,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12984,8 +13285,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12994,11 +13295,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13024,7 +13326,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13033,11 +13335,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13046,7 +13349,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13055,11 +13358,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13068,8 +13372,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13103,7 +13407,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13120,8 +13424,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13130,12 +13434,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13147,8 +13452,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13157,7 +13462,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13193,7 +13498,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13212,8 +13517,8 @@
     <measure implicit="no" number="53">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13239,8 +13544,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13249,11 +13554,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13262,13 +13568,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13293,7 +13600,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13302,16 +13609,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13319,8 +13626,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13332,8 +13639,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13343,16 +13650,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13362,16 +13669,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13379,8 +13686,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13392,8 +13699,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13403,15 +13710,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13438,8 +13745,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13494,8 +13801,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13511,8 +13818,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13546,8 +13853,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13572,8 +13879,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13585,7 +13892,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13594,8 +13901,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13605,7 +13912,7 @@
     <measure implicit="no" number="55">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -13631,8 +13938,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -13679,7 +13986,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13696,8 +14003,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13732,7 +14039,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13741,8 +14048,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13754,7 +14061,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13767,7 +14074,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13776,11 +14083,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13789,7 +14097,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13798,8 +14106,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13811,7 +14119,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13820,8 +14128,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13833,7 +14141,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13844,15 +14152,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13863,8 +14171,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13880,8 +14188,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13907,8 +14215,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13917,6 +14225,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13925,8 +14234,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13951,8 +14260,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13966,8 +14275,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13992,8 +14301,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14018,8 +14327,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14036,7 +14345,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14049,8 +14358,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14058,8 +14367,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14071,8 +14380,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14081,7 +14390,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14092,8 +14401,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14103,8 +14412,8 @@
     <measure implicit="no" number="57">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14112,7 +14421,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14125,8 +14434,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14136,16 +14445,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14176,8 +14485,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14202,8 +14511,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14217,8 +14526,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14230,8 +14539,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14247,7 +14556,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14274,8 +14583,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14297,8 +14606,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14314,8 +14623,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14324,6 +14633,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -14340,8 +14650,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14350,6 +14660,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -14360,8 +14671,8 @@
     <measure implicit="no" number="58">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14386,8 +14697,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14409,8 +14720,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14426,8 +14737,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14444,8 +14755,32 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14453,8 +14788,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14466,8 +14801,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14475,30 +14810,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
         <duration>2520</duration>
         <type>16th</type>
       </note>
-      <note>
+      <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14510,21 +14837,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14586,8 +14900,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14603,8 +14917,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14639,7 +14953,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14652,7 +14966,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14661,11 +14975,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14687,8 +15002,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14696,8 +15011,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14709,7 +15024,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14718,8 +15033,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14731,7 +15046,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14740,11 +15055,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14766,8 +15082,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14792,8 +15108,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14815,8 +15131,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14828,8 +15144,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14845,7 +15161,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14892,7 +15208,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14901,8 +15217,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14914,8 +15230,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14927,8 +15243,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14940,8 +15256,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14953,8 +15269,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14979,8 +15295,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14993,7 +15309,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15011,8 +15327,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15033,7 +15349,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15043,8 +15359,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15058,7 +15374,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15068,8 +15384,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15077,8 +15393,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15092,7 +15408,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15102,8 +15418,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15112,8 +15428,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15127,7 +15443,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15142,23 +15473,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -15182,8 +15498,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -15197,8 +15513,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -15211,8 +15527,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15222,8 +15538,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15234,8 +15550,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15243,8 +15559,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15274,8 +15590,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -15289,8 +15605,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -15306,8 +15622,8 @@
     <measure implicit="no" number="64">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15315,8 +15631,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15328,8 +15644,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15339,16 +15655,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15358,15 +15674,76 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15379,8 +15756,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15390,25 +15767,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
-        <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15416,18 +15784,10 @@
         <beam number="2">end</beam>
       </note>
       <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15439,51 +15799,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15508,8 +15825,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15531,7 +15848,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15548,8 +15865,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15564,8 +15881,8 @@
     <measure implicit="no" number="65">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15574,7 +15891,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15585,16 +15902,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15604,16 +15921,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15623,8 +15940,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15636,8 +15953,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15647,16 +15964,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15666,8 +15983,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15679,8 +15996,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15688,7 +16005,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15701,8 +16018,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15711,7 +16028,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15739,8 +16056,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15757,8 +16074,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15783,8 +16100,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15812,8 +16129,8 @@
     <measure implicit="no" number="66">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15822,7 +16139,33 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15837,33 +16180,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15874,8 +16192,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15883,8 +16201,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15894,8 +16212,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15911,18 +16229,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15933,8 +16252,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15945,8 +16264,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -15960,8 +16279,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -15985,8 +16304,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16013,8 +16332,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -16036,7 +16355,7 @@
     <measure implicit="no" number="67">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16049,11 +16368,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16062,18 +16382,19 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16082,17 +16403,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16103,15 +16425,60 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16124,8 +16491,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16133,52 +16500,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16193,8 +16516,8 @@
     <measure implicit="no" number="68">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16209,8 +16532,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16223,8 +16546,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16238,8 +16561,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16254,7 +16577,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16268,8 +16591,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16278,7 +16601,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16293,8 +16616,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16303,8 +16626,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16318,8 +16641,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16330,8 +16653,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16339,8 +16662,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16350,8 +16673,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16362,8 +16685,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16377,7 +16700,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16393,8 +16716,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16408,8 +16731,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16422,8 +16745,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16438,7 +16761,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16452,7 +16775,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16481,8 +16804,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -16504,22 +16827,24 @@
     <measure implicit="no" number="69">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16529,8 +16854,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16541,16 +16866,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16571,8 +16897,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16587,7 +16913,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16601,8 +16927,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16617,8 +16943,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16631,8 +16957,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16646,8 +16972,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16656,8 +16982,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -16671,7 +16997,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16686,8 +17012,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -16702,7 +17028,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16716,7 +17042,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16750,20 +17076,21 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 70 =========================-->
     <measure implicit="no" number="70">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16772,6 +17099,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -16789,8 +17117,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16802,8 +17130,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16817,8 +17145,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16843,17 +17171,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16865,8 +17194,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16876,16 +17205,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16895,16 +17224,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16914,16 +17243,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16949,8 +17278,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16962,8 +17291,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16976,8 +17305,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16993,8 +17322,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17019,7 +17348,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17034,8 +17363,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17044,6 +17373,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17063,7 +17393,7 @@
     <measure implicit="no" number="71">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17075,17 +17405,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -17100,7 +17431,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17125,8 +17456,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -17139,7 +17470,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17154,8 +17485,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -17170,7 +17501,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17195,8 +17526,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <voice>1</voice>
@@ -17212,8 +17543,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <voice>1</voice>
@@ -17226,8 +17557,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <voice>1</voice>
@@ -17244,8 +17575,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <voice>1</voice>
@@ -17258,8 +17589,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -17268,8 +17599,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -17283,8 +17614,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -17295,8 +17626,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -17304,8 +17635,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -17316,8 +17647,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -17325,8 +17656,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -17336,7 +17667,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17352,8 +17683,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -17363,12 +17694,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -17392,8 +17724,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -17424,7 +17756,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17434,8 +17766,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
@@ -17446,7 +17778,7 @@
     <measure implicit="no" number="72">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -17472,8 +17804,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -17520,7 +17852,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17538,8 +17870,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17551,8 +17883,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17579,7 +17911,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17593,8 +17925,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17606,8 +17938,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17616,8 +17948,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17627,7 +17959,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17636,16 +17968,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17655,8 +17987,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17668,7 +18000,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17679,35 +18011,36 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17717,8 +18050,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17730,8 +18063,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17741,15 +18074,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17760,25 +18093,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17787,7 +18121,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17798,8 +18132,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17809,8 +18143,8 @@
     <measure implicit="no" number="73">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17836,8 +18170,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17849,8 +18183,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17864,8 +18198,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17877,8 +18211,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17894,17 +18228,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17916,7 +18251,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17925,16 +18260,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17942,8 +18277,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17955,7 +18290,36 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17966,54 +18330,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18022,7 +18358,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18032,18 +18368,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18052,11 +18389,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 74 =========================-->
@@ -18068,7 +18406,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18079,16 +18417,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18097,6 +18436,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -18114,7 +18454,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18128,8 +18468,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18138,6 +18478,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18151,7 +18492,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18168,8 +18509,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18178,12 +18519,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18192,11 +18534,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18206,16 +18549,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18225,8 +18568,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18238,7 +18581,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18265,8 +18608,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18279,8 +18622,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18289,6 +18632,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18297,7 +18641,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18323,8 +18667,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18333,6 +18677,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18349,8 +18694,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18358,7 +18703,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18374,8 +18719,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18384,6 +18729,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -18400,8 +18746,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18423,7 +18769,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18440,8 +18786,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18454,8 +18800,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18467,8 +18813,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18476,8 +18822,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18489,8 +18835,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18498,8 +18844,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18511,8 +18857,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18521,7 +18867,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18531,8 +18877,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18542,7 +18888,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18551,11 +18897,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18564,7 +18911,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18599,8 +18946,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18616,8 +18963,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18626,11 +18973,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18646,8 +18994,8 @@
     <measure implicit="no" number="76">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -18662,8 +19010,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -18673,10 +19021,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18702,7 +19051,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18712,8 +19071,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18722,27 +19091,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18756,7 +19106,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18768,8 +19118,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18777,8 +19127,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18789,8 +19139,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18804,8 +19154,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18816,8 +19166,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18825,8 +19175,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18842,8 +19192,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -18853,7 +19203,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18869,8 +19219,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -18894,7 +19244,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18909,8 +19274,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -18920,21 +19285,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <backup>
         <duration>40320</duration>
@@ -18952,7 +19303,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18967,8 +19318,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -18978,12 +19329,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -19005,8 +19357,8 @@
     <measure implicit="no" number="77">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19032,8 +19384,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19042,10 +19394,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19059,8 +19412,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19077,7 +19430,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19091,8 +19444,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19101,11 +19454,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19131,8 +19485,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19144,7 +19498,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19159,8 +19513,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19185,7 +19539,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19194,8 +19548,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19207,8 +19561,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19218,7 +19572,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19226,8 +19580,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19241,7 +19595,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19267,8 +19621,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19290,8 +19644,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19307,8 +19661,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19323,8 +19677,8 @@
     <measure implicit="no" number="78">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19339,8 +19693,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19353,8 +19707,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19369,8 +19723,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19383,8 +19737,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19399,8 +19753,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19413,8 +19767,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19429,8 +19783,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19443,8 +19797,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19459,8 +19813,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19473,8 +19827,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19489,8 +19843,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19503,8 +19857,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19519,8 +19873,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19533,8 +19887,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -19555,8 +19909,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19580,7 +19934,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19595,8 +19949,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19606,6 +19960,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <backup>
         <duration>40320</duration>
@@ -19624,7 +19979,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19634,18 +19989,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
@@ -19659,7 +20015,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19674,8 +20030,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -19702,17 +20058,18 @@
     <measure implicit="no" number="79">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19727,7 +20084,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19737,7 +20104,72 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19747,8 +20179,79 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -19762,149 +20265,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <voice>1</voice>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19928,7 +20290,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19943,8 +20305,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -19954,6 +20316,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <backup>
         <duration>40320</duration>
@@ -19967,7 +20330,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19982,8 +20345,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -19997,8 +20360,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>2</voice>
@@ -20008,6 +20371,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20025,8 +20389,8 @@
     <measure implicit="no" number="80">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20035,6 +20399,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -20052,7 +20417,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20065,8 +20430,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20075,13 +20440,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20093,7 +20459,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20111,8 +20477,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20121,12 +20487,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20138,8 +20505,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20148,7 +20515,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20159,7 +20526,30 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20168,7 +20558,89 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20181,56 +20653,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20240,24 +20664,25 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20268,69 +20693,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20345,8 +20719,8 @@
     <measure implicit="no" number="81">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20355,6 +20729,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -20371,7 +20746,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20385,8 +20760,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20408,7 +20783,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20425,8 +20800,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20435,12 +20810,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20452,8 +20828,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20462,7 +20838,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20489,8 +20865,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20512,8 +20888,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20526,8 +20902,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20539,8 +20915,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20557,8 +20933,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20570,7 +20946,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20597,8 +20973,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20607,6 +20983,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20620,7 +20997,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -20636,8 +21013,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -20649,7 +21026,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -20666,8 +21043,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -20679,7 +21056,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20696,8 +21073,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20706,6 +21083,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20731,8 +21109,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20748,7 +21126,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20762,8 +21140,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20772,6 +21150,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 82 =========================-->
@@ -20788,7 +21167,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20797,11 +21176,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20810,7 +21190,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20819,8 +21199,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20828,11 +21208,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20841,7 +21222,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20867,8 +21248,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20890,8 +21271,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20900,11 +21281,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20917,8 +21299,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20934,7 +21316,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20948,8 +21330,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20958,6 +21340,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20983,8 +21366,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20993,6 +21376,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -21000,8 +21384,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21016,8 +21400,8 @@
     <measure implicit="no" number="83">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21043,8 +21427,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21056,8 +21440,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21071,8 +21455,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21084,8 +21468,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21102,8 +21486,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21115,7 +21499,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21150,7 +21534,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21167,8 +21551,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21181,8 +21565,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21191,6 +21575,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21199,7 +21584,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21212,7 +21597,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21225,7 +21610,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21251,8 +21636,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21261,6 +21646,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21274,7 +21660,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21291,8 +21677,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21305,8 +21691,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21315,6 +21701,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 84 =========================-->
@@ -21326,7 +21713,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21337,27 +21724,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21369,7 +21757,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21380,25 +21768,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21407,6 +21796,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -21424,7 +21814,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21447,8 +21837,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21464,8 +21854,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21474,10 +21864,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21488,26 +21879,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21520,7 +21913,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21529,20 +21931,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21551,7 +21945,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21560,8 +21954,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21569,11 +21963,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21585,7 +21980,7 @@
     <measure implicit="no" number="85">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21612,8 +22007,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21622,12 +22017,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21639,8 +22035,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21649,11 +22045,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21671,8 +22068,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21681,6 +22078,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21706,7 +22104,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21720,8 +22118,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21730,6 +22128,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21746,8 +22145,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21755,11 +22154,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21768,8 +22168,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21828,7 +22228,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21845,8 +22245,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21855,6 +22255,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 86 =========================-->
@@ -21866,8 +22267,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21892,8 +22293,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21902,6 +22303,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21915,7 +22317,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21932,8 +22334,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21942,6 +22344,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21950,7 +22353,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21960,8 +22363,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21971,7 +22374,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21980,11 +22383,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21993,7 +22397,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22002,8 +22406,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22011,8 +22415,31 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22024,30 +22451,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22057,15 +22462,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22076,11 +22481,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22092,7 +22498,7 @@
     <measure implicit="no" number="87">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22101,8 +22507,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22110,11 +22516,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22123,7 +22530,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22132,11 +22539,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22145,7 +22553,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22171,8 +22579,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22186,7 +22594,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22200,8 +22608,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22210,6 +22618,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22226,7 +22635,24 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22235,16 +22661,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22252,20 +22670,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22274,7 +22684,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22283,11 +22693,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22296,17 +22707,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22333,8 +22745,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22343,6 +22755,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22356,8 +22769,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22366,6 +22779,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -22373,7 +22787,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22389,8 +22803,8 @@
     <measure implicit="no" number="88">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22400,15 +22814,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22435,8 +22850,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22445,12 +22860,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22472,8 +22888,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22482,11 +22898,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22499,8 +22916,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22516,7 +22933,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22530,8 +22947,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22540,6 +22957,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22565,8 +22983,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22575,11 +22993,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22592,8 +23011,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22610,8 +23029,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22620,10 +23039,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22650,8 +23070,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22660,12 +23080,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22677,8 +23098,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22687,6 +23108,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -22694,7 +23116,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22703,11 +23125,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22716,7 +23139,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22725,18 +23148,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 89 =========================-->
     <measure implicit="no" number="89">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -22762,8 +23186,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -22772,6 +23196,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22810,7 +23235,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22827,8 +23252,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22837,6 +23262,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22875,8 +23301,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22888,11 +23314,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22902,7 +23329,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22911,20 +23338,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22933,8 +23362,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22942,7 +23371,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22958,8 +23387,8 @@
     <measure implicit="no" number="90">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22967,8 +23396,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22980,8 +23409,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22993,7 +23422,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23006,7 +23435,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23015,20 +23453,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23037,7 +23467,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23046,20 +23485,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23068,7 +23499,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23077,8 +23508,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23090,8 +23521,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23116,8 +23547,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23146,7 +23577,7 @@
     <measure implicit="no" number="91">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23173,8 +23604,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23183,11 +23614,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23201,7 +23633,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23215,8 +23647,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23225,6 +23657,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23241,8 +23674,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23254,8 +23687,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23280,7 +23713,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23303,8 +23736,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23320,8 +23753,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23330,6 +23763,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23338,8 +23772,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23351,7 +23785,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23360,11 +23794,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23373,8 +23808,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23408,7 +23843,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23425,8 +23860,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23435,6 +23870,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 92 =========================-->
@@ -23446,7 +23882,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23455,11 +23891,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23469,7 +23906,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23495,8 +23932,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23505,6 +23942,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23518,7 +23956,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23535,8 +23973,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23545,6 +23983,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23553,7 +23992,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23564,26 +24003,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23596,7 +24037,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23622,8 +24063,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23632,6 +24073,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23645,8 +24087,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23655,6 +24097,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -23662,7 +24105,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23678,8 +24121,8 @@
     <measure implicit="no" number="93">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -23694,8 +24137,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -23708,8 +24151,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -23724,8 +24167,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -23738,8 +24181,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -23754,8 +24197,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -23768,7 +24211,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23784,8 +24227,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -23795,12 +24238,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <voice>1</voice>
@@ -23813,8 +24257,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -23835,7 +24279,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23845,12 +24289,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23860,7 +24305,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23871,8 +24316,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -23883,7 +24328,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23893,12 +24338,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23908,8 +24354,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -23920,16 +24366,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23941,8 +24388,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
@@ -23951,12 +24398,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>1</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23976,7 +24424,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23986,8 +24434,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
@@ -23996,12 +24444,13 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <voice>2</voice>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24020,7 +24469,7 @@
     <measure implicit="no" number="94">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24029,17 +24478,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24051,26 +24501,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24081,17 +24532,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24103,7 +24555,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24129,8 +24581,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24143,8 +24595,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24153,6 +24605,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24166,7 +24619,21 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24180,8 +24647,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24190,25 +24657,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24225,8 +24679,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24235,10 +24689,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24264,8 +24719,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24279,7 +24734,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24293,8 +24748,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24303,11 +24758,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24323,7 +24779,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24350,8 +24806,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24364,8 +24820,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24374,6 +24830,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24387,7 +24844,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -24403,8 +24860,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -24413,10 +24870,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -24436,8 +24894,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -24446,6 +24904,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 95 =========================-->
@@ -24457,26 +24916,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24487,11 +24947,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24500,7 +24961,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24509,8 +24970,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24518,11 +24979,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24531,7 +24993,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24540,11 +25002,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24553,8 +25016,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24579,7 +25042,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24594,8 +25057,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24604,6 +25067,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24623,7 +25087,7 @@
     <measure implicit="no" number="96">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24636,7 +25100,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24646,17 +25110,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24665,11 +25130,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24678,7 +25144,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24687,11 +25153,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24700,7 +25167,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24709,11 +25176,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24722,7 +25190,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24731,11 +25199,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24744,7 +25213,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24753,20 +25231,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24775,7 +25245,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24784,20 +25263,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24814,7 +25285,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24825,16 +25296,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24844,7 +25316,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24853,11 +25325,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24866,7 +25339,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24875,20 +25357,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24897,8 +25371,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24924,7 +25398,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24938,8 +25412,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24948,6 +25422,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24956,7 +25431,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24982,8 +25457,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24992,6 +25467,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25008,7 +25484,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25019,16 +25495,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25038,7 +25515,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25047,11 +25524,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25060,7 +25538,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25069,28 +25556,20 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 98 =========================-->
     <measure implicit="no" number="98">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -25115,7 +25594,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -25129,8 +25608,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -25139,6 +25618,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25177,8 +25657,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25194,7 +25674,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25208,8 +25688,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25218,6 +25698,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25244,7 +25725,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25253,7 +25734,30 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25266,8 +25770,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25275,7 +25779,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25288,8 +25802,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25297,38 +25811,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25341,7 +25824,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25350,11 +25833,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25366,7 +25850,16 @@
     <measure implicit="no" number="99">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25375,20 +25868,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25398,7 +25883,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25411,8 +25896,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25424,7 +25909,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25434,7 +25919,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25449,7 +25934,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25476,8 +25961,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25486,6 +25971,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25494,7 +25980,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25532,8 +26018,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25548,7 +26034,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25557,8 +26043,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25570,7 +26056,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25579,11 +26065,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25592,7 +26079,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25605,7 +26092,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25614,20 +26110,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25636,8 +26124,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25645,11 +26133,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25658,7 +26147,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25669,15 +26158,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25688,20 +26177,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25710,7 +26201,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25721,8 +26212,8 @@
     <measure implicit="no" number="101">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25747,7 +26238,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25761,8 +26252,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25771,6 +26262,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25784,8 +26276,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25805,18 +26297,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25824,8 +26317,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25835,15 +26328,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25858,7 +26351,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25867,17 +26369,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
-        <chord />
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25889,30 +26396,18 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note dynamics="111.11">
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25923,17 +26418,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25948,7 +26444,7 @@
     <measure implicit="no" number="102">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25974,8 +26470,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25997,7 +26493,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26014,8 +26510,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26024,12 +26520,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26041,11 +26538,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -26054,7 +26552,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26063,7 +26561,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26072,11 +26570,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -26086,11 +26585,12 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -26099,7 +26599,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26109,8 +26609,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26120,8 +26620,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26133,8 +26633,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
@@ -26148,8 +26648,8 @@
     <measure implicit="no" number="103">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -26210,8 +26710,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26248,7 +26748,35 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26262,36 +26790,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26316,7 +26816,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26325,8 +26825,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26343,18 +26843,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26362,8 +26863,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
@@ -26379,8 +26880,8 @@
     <measure implicit="no" number="104">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -26441,7 +26942,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26458,8 +26959,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26485,8 +26986,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26498,8 +26999,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26511,7 +27012,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26537,8 +27038,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26552,8 +27053,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26565,8 +27066,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26583,8 +27084,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26601,26 +27102,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26638,8 +27140,8 @@
     <measure implicit="no" number="105">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26649,16 +27151,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26684,8 +27186,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26707,7 +27209,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26724,8 +27226,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26742,7 +27244,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26753,7 +27255,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26761,8 +27263,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26772,8 +27274,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26785,7 +27287,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26795,8 +27297,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26805,8 +27307,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26816,15 +27318,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26834,8 +27336,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26860,7 +27362,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26887,8 +27389,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26898,7 +27400,7 @@
     <measure implicit="no" number="106">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26907,7 +27409,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26916,8 +27418,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26929,7 +27431,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26938,7 +27440,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26951,8 +27453,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26977,8 +27479,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27000,8 +27502,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27014,8 +27516,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27027,8 +27529,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27044,7 +27546,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -27071,8 +27573,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27085,8 +27587,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27108,7 +27610,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -27125,8 +27627,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27152,8 +27654,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27175,8 +27677,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <tie type="start" />
@@ -27194,8 +27696,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -27218,8 +27720,8 @@
     <measure implicit="no" number="107">
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27244,8 +27746,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27258,7 +27760,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -27276,8 +27778,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27289,7 +27791,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27298,8 +27800,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -27311,7 +27813,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27320,8 +27822,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -27333,7 +27835,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27342,8 +27844,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -27356,7 +27858,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27365,20 +27867,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -27397,7 +27901,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27406,11 +27910,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />

--- a/public/transcription-samples/night-in-tunisia/adtof-plus-drums/ADP44b5ee9df0a6_drum_transcription.musicxml
+++ b/public/transcription-samples/night-in-tunisia/adtof-plus-drums/ADP44b5ee9df0a6_drum_transcription.musicxml
@@ -5,8 +5,11 @@
   <identification>
     <creator type="composer">Music21</creator>
     <encoding>
-      <encoding-date>2026-07-03</encoding-date>
-      <software>music21 v.9.9.2</software>
+      <encoding-date>2026-07-05</encoding-date>
+      <software>music21 v.10.5.0</software>
+      <supports element="beam" type="yes" />
+      <supports element="stem" type="yes" />
+      <supports element="accidental" type="yes" />
     </encoding>
   </identification>
   <defaults>
@@ -16,21 +19,21 @@
     </scaling>
   </defaults>
   <part-list>
-    <score-part id="Pcd7ae66c623fd0efdb265f90893d373b">
+    <score-part id="P35825b4ab911ef25dc64ea6ceb615fec">
       <part-name>Percussion</part-name>
       <part-abbreviation>Perc</part-abbreviation>
-      <score-instrument id="If1f00b0c89bd23560053ce196c0bd14c">
+      <score-instrument id="I4ec0db4e6dc37babf039587659097233">
         <instrument-name>Percussion</instrument-name>
         <instrument-abbreviation>Perc</instrument-abbreviation>
       </score-instrument>
-      <midi-instrument id="If1f00b0c89bd23560053ce196c0bd14c">
+      <midi-instrument id="I4ec0db4e6dc37babf039587659097233">
         <midi-channel>10</midi-channel>
         <midi-program>1</midi-program>
       </midi-instrument>
     </score-part>
   </part-list>
   <!--=========================== Part 1 ===========================-->
-  <part id="Pcd7ae66c623fd0efdb265f90893d373b">
+  <part id="P35825b4ab911ef25dc64ea6ceb615fec">
     <!--========================= Measure 1 ==========================-->
     <measure implicit="no" number="1">
       <attributes>
@@ -40,8 +43,7 @@
           <beat-type>4</beat-type>
         </time>
         <clef>
-          <sign>G</sign>
-          <line>2</line>
+          <sign>percussion</sign>
         </clef>
       </attributes>
       <direction>
@@ -105,8 +107,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -119,8 +121,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -142,7 +144,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -159,8 +161,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -169,6 +171,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -177,8 +180,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -203,7 +206,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -217,8 +220,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -231,8 +234,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -241,6 +244,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -254,7 +258,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -272,8 +276,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -286,8 +290,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -296,11 +300,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -309,6 +314,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -326,7 +332,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -340,8 +346,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -353,8 +359,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -363,13 +369,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -381,7 +388,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -399,8 +406,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -409,11 +416,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -422,6 +430,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -439,7 +448,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -452,8 +461,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -470,8 +479,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -480,13 +489,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 6 ==========================-->
     <measure implicit="no" number="6">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -495,17 +505,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -517,26 +528,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -564,8 +576,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -574,6 +586,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -582,7 +595,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -609,8 +622,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -623,8 +636,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -633,11 +646,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -651,7 +665,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -664,8 +678,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -674,6 +688,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -682,8 +697,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -692,11 +707,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -722,7 +738,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -736,8 +752,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -746,6 +762,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -762,7 +779,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -771,20 +797,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -793,7 +811,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -804,16 +822,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -823,8 +841,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -839,8 +857,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -850,16 +868,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -869,7 +887,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -878,11 +896,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -891,7 +910,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -917,8 +936,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -931,8 +950,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -941,6 +960,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -954,8 +974,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -971,7 +991,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -984,7 +1004,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -993,17 +1023,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1015,17 +1036,18 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1053,8 +1075,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1063,6 +1085,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1071,7 +1094,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1097,8 +1120,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1111,8 +1134,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1121,6 +1144,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -1140,7 +1164,7 @@
     <measure implicit="no" number="8">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1151,25 +1175,27 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1180,11 +1206,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -1193,7 +1220,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1219,8 +1246,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1233,8 +1260,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1243,6 +1270,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -1256,7 +1284,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1273,8 +1301,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1286,16 +1314,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1308,7 +1337,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1317,20 +1355,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -1339,8 +1369,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1350,16 +1380,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1385,8 +1415,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1408,8 +1438,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1425,8 +1455,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1441,8 +1471,8 @@
     <measure implicit="no" number="9">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1468,8 +1498,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1481,8 +1511,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1496,7 +1526,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1510,8 +1540,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1520,6 +1550,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1536,7 +1567,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1545,8 +1576,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1558,7 +1589,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1567,8 +1598,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1580,8 +1611,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1590,6 +1621,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -1607,7 +1639,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1621,8 +1653,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1634,8 +1666,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1649,7 +1681,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1663,8 +1695,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1677,8 +1709,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1687,6 +1719,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1703,8 +1736,8 @@
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1716,7 +1749,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1725,8 +1758,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1734,11 +1767,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1747,7 +1781,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -1756,8 +1790,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1767,8 +1801,95 @@
     <measure implicit="no" number="10">
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1780,92 +1901,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1874,6 +1911,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -1891,7 +1929,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1905,8 +1943,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1918,8 +1956,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1933,7 +1971,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -1947,8 +1985,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1961,8 +1999,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -1971,6 +2009,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -1987,8 +2026,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -1998,7 +2037,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2006,8 +2045,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2017,11 +2056,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2033,8 +2073,8 @@
     <measure implicit="no" number="11">
       <note dynamics="57.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2059,7 +2099,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2074,8 +2114,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2088,8 +2128,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2114,8 +2154,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2123,7 +2163,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2131,8 +2171,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2140,11 +2180,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2153,7 +2194,7 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2163,18 +2204,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2187,8 +2229,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2213,7 +2255,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2227,8 +2269,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2241,8 +2283,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2251,6 +2293,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2264,8 +2307,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2281,8 +2324,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2294,7 +2337,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2303,8 +2346,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2316,8 +2359,8 @@
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2326,8 +2369,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2337,8 +2380,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2353,7 +2396,7 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2361,17 +2404,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2379,7 +2413,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2392,7 +2435,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2401,11 +2444,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -2414,7 +2458,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2423,8 +2467,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2432,8 +2476,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2441,8 +2485,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2459,7 +2503,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2486,8 +2530,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2496,10 +2540,29 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2508,16 +2571,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2525,20 +2580,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -2550,7 +2597,7 @@
     <measure implicit="no" number="13">
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2563,18 +2610,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2582,19 +2630,20 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2606,7 +2655,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2617,26 +2666,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2644,8 +2695,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2655,11 +2706,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -2668,7 +2720,7 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2678,11 +2730,12 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -2693,7 +2746,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2704,26 +2757,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2731,8 +2786,8 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -2749,7 +2804,7 @@
     <measure implicit="no" number="14">
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -2759,8 +2814,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2769,6 +2824,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -2786,7 +2842,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2800,8 +2856,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2823,8 +2879,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2833,12 +2889,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2850,7 +2907,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2868,8 +2925,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2878,12 +2935,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2895,8 +2953,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2905,6 +2963,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -2922,7 +2981,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -2935,8 +2994,8 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2949,8 +3008,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2967,8 +3026,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -2980,8 +3039,8 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3006,7 +3065,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3024,8 +3083,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3034,6 +3093,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3042,7 +3102,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3051,8 +3111,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3060,11 +3120,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3073,7 +3134,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3082,17 +3143,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3102,16 +3164,17 @@
     <measure implicit="no" number="15">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3124,17 +3187,18 @@
       </note>
       <note dynamics="98.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3162,8 +3226,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3172,12 +3236,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3194,7 +3259,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3220,8 +3285,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3246,7 +3311,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3255,11 +3320,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3268,17 +3334,18 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3289,11 +3356,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3302,7 +3370,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3311,11 +3379,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3324,8 +3393,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3333,8 +3402,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3350,7 +3419,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3361,26 +3430,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3389,8 +3460,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3402,8 +3473,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3413,15 +3484,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3432,26 +3504,27 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3464,17 +3537,18 @@
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3485,11 +3559,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3501,20 +3576,22 @@
     <measure implicit="no" number="17">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3523,37 +3600,40 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3562,6 +3642,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -3578,7 +3659,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3592,8 +3673,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3615,8 +3696,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3625,6 +3706,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -3632,7 +3714,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3645,8 +3727,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3672,8 +3754,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3682,10 +3764,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3700,8 +3783,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3710,12 +3793,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3740,16 +3824,17 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3757,8 +3842,8 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3767,6 +3852,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -3783,7 +3869,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3798,8 +3884,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3808,11 +3894,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3821,6 +3908,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -3829,7 +3917,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3845,8 +3933,8 @@
     <measure implicit="no" number="18">
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3855,6 +3943,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -3871,7 +3960,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -3886,8 +3975,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -3896,6 +3985,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -3912,15 +4002,16 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3929,11 +4020,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3942,18 +4034,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -3961,8 +4054,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3972,8 +4065,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -3981,11 +4074,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -3994,7 +4088,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4005,26 +4099,27 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4032,11 +4127,12 @@
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -4047,7 +4143,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4058,26 +4154,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4085,8 +4183,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4096,11 +4194,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 19 =========================-->
@@ -4112,7 +4211,7 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4125,7 +4224,7 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4138,7 +4237,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4147,8 +4246,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4156,11 +4255,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4169,8 +4269,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4179,6 +4279,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4195,8 +4296,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4205,6 +4306,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4243,8 +4345,8 @@
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4257,8 +4359,8 @@
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4267,6 +4369,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -4277,8 +4380,50 @@
     <measure implicit="no" number="20">
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>5040</duration>
+        <type>eighth</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4290,8 +4435,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4299,16 +4444,32 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4316,11 +4477,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4329,20 +4491,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4351,7 +4515,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4360,73 +4533,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>5040</duration>
-        <type>eighth</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4438,7 +4550,31 @@
     <measure implicit="no" number="21">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4447,8 +4583,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4460,39 +4596,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4504,8 +4619,8 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4514,6 +4629,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4535,7 +4651,7 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4570,8 +4686,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4580,6 +4696,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -4587,8 +4704,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4605,7 +4722,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4631,8 +4748,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4645,8 +4762,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4655,6 +4772,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4671,17 +4789,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4691,8 +4810,8 @@
     <measure implicit="no" number="22">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -4701,6 +4820,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -4717,8 +4837,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -4765,8 +4885,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4782,8 +4902,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4795,8 +4915,8 @@
       </note>
       <note dynamics="140.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4808,7 +4928,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4817,11 +4937,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -4830,7 +4951,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -4839,8 +4960,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4848,8 +4969,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -4857,20 +4978,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4880,8 +5003,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4906,7 +5029,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4920,8 +5043,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4930,6 +5053,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -4943,7 +5067,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -4960,8 +5084,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4974,8 +5098,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -4984,6 +5108,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 23 =========================-->
@@ -4995,7 +5120,7 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5005,18 +5130,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5024,11 +5150,12 @@
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -5039,7 +5166,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5065,8 +5192,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5075,12 +5202,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5102,7 +5230,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5119,8 +5247,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5133,8 +5261,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5143,6 +5271,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -5151,7 +5280,7 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5164,7 +5293,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5173,20 +5311,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5195,8 +5325,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5205,6 +5335,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -5221,7 +5352,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5244,8 +5375,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5261,8 +5392,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5271,13 +5402,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 24 =========================-->
     <measure implicit="no" number="24">
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5303,8 +5435,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5313,12 +5445,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5331,8 +5464,8 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5341,6 +5474,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -5348,7 +5482,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5359,25 +5493,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5386,6 +5521,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5403,7 +5539,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5426,8 +5562,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5440,8 +5576,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5450,10 +5586,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5470,8 +5607,8 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5480,6 +5617,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">continue</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -5496,7 +5634,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5514,8 +5652,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5524,6 +5662,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5532,7 +5671,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5558,8 +5697,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5572,8 +5711,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5582,6 +5721,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5595,7 +5735,7 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5614,16 +5754,17 @@
     <measure implicit="no" number="25">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5636,7 +5777,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5645,20 +5795,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5667,7 +5809,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5693,8 +5835,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5707,8 +5849,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5717,6 +5859,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5730,8 +5873,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5744,8 +5887,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5757,8 +5900,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5775,8 +5918,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -5788,7 +5931,7 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -5824,8 +5967,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -5840,8 +5983,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -5854,7 +5997,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -5867,8 +6010,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -5887,8 +6030,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -5901,7 +6044,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -5914,7 +6057,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5923,11 +6066,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5936,7 +6080,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -5945,8 +6089,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5954,8 +6098,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5963,11 +6107,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -5985,8 +6130,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -5994,8 +6139,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6007,7 +6152,7 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6042,7 +6187,7 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6063,7 +6208,7 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6073,8 +6218,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6084,8 +6229,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6097,7 +6242,7 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6110,7 +6255,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6119,11 +6264,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 27 =========================-->
@@ -6135,7 +6281,7 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6170,8 +6316,8 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6180,6 +6326,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6196,7 +6343,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6222,8 +6369,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6232,6 +6379,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6245,7 +6393,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -6261,8 +6409,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -6275,8 +6423,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -6285,10 +6433,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -6307,8 +6456,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -6321,8 +6470,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -6331,6 +6480,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6339,7 +6489,7 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6365,8 +6515,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6375,12 +6525,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6406,7 +6557,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6432,8 +6583,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6442,6 +6593,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6461,7 +6613,7 @@
     <measure implicit="no" number="28">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6470,11 +6622,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6488,7 +6641,7 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6501,7 +6654,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6510,8 +6663,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6519,11 +6672,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6532,7 +6686,7 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6545,7 +6699,7 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6580,7 +6734,7 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6599,7 +6753,7 @@
     <measure implicit="no" number="29">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6625,8 +6779,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6639,8 +6793,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6649,6 +6803,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6662,7 +6817,7 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6678,8 +6833,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6688,6 +6843,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -6713,7 +6869,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -6730,8 +6886,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6740,6 +6896,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6765,8 +6922,8 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -6775,6 +6932,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6791,8 +6949,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6800,8 +6958,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6809,11 +6967,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6822,11 +6981,12 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6838,7 +6998,7 @@
     <measure implicit="no" number="30">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6847,11 +7007,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6860,7 +7021,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6869,11 +7030,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6882,8 +7044,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6891,8 +7053,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6900,11 +7062,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6913,11 +7076,12 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -6926,7 +7090,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6935,8 +7099,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -6944,11 +7108,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -6957,7 +7122,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -6966,25 +7131,27 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7009,7 +7176,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7032,8 +7199,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7049,8 +7216,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7063,8 +7230,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7073,14 +7240,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 31 =========================-->
     <measure implicit="no" number="31">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7089,6 +7257,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -7106,8 +7275,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7116,11 +7285,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7134,7 +7304,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7148,8 +7318,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7158,12 +7328,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7188,8 +7359,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7197,7 +7368,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7205,8 +7376,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7215,6 +7386,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -7232,8 +7404,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7245,7 +7417,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7260,8 +7432,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7270,6 +7442,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7286,8 +7459,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7295,11 +7468,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -7308,26 +7482,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7338,17 +7514,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7360,7 +7537,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7369,11 +7546,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7382,7 +7560,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7393,16 +7571,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7412,8 +7591,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7428,17 +7607,18 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7449,8 +7629,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7462,8 +7642,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7489,8 +7669,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7502,8 +7682,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7517,8 +7697,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7530,8 +7710,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7548,8 +7728,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7561,8 +7741,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7587,8 +7767,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7601,7 +7781,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7619,8 +7799,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7646,8 +7826,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7655,8 +7835,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7668,7 +7848,7 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7683,7 +7863,7 @@
     <measure implicit="no" number="34">
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -7745,7 +7925,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7762,8 +7942,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7772,6 +7952,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7798,7 +7979,7 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7808,18 +7989,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7832,7 +8014,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7841,17 +8023,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -7863,7 +8046,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -7872,11 +8055,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -7885,7 +8069,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7912,8 +8096,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7926,8 +8110,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7939,8 +8123,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7954,8 +8138,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7967,7 +8151,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -7985,8 +8169,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -7995,14 +8179,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 35 =========================-->
     <measure implicit="no" number="35">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8011,6 +8196,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8028,7 +8214,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8042,8 +8228,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8055,8 +8241,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8070,8 +8256,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8080,10 +8266,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8100,8 +8287,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8110,6 +8297,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8127,7 +8315,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8140,8 +8328,8 @@
       </note>
       <note dynamics="92.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8150,6 +8338,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
@@ -8167,7 +8356,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8176,24 +8365,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8206,8 +8397,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8217,15 +8408,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8236,19 +8428,21 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8257,7 +8451,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8268,8 +8462,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8277,35 +8471,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8314,8 +8510,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8330,8 +8526,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8341,39 +8537,42 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8382,27 +8581,29 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8413,17 +8614,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8435,18 +8637,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8454,8 +8657,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8481,8 +8684,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8491,6 +8694,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8504,7 +8708,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8521,8 +8725,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8531,20 +8735,22 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8555,11 +8761,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8571,7 +8778,7 @@
     <measure implicit="no" number="37">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -8580,8 +8787,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8589,8 +8796,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -8598,11 +8805,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -8611,7 +8819,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8638,8 +8846,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8648,6 +8856,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -8656,8 +8865,8 @@
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8666,6 +8875,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8682,8 +8892,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8697,8 +8907,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8710,7 +8920,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8728,8 +8938,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8738,11 +8948,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8751,6 +8962,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8768,7 +8980,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8781,8 +8993,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8796,8 +9008,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8806,11 +9018,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8819,6 +9032,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -8827,7 +9041,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8841,8 +9055,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8851,11 +9065,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8864,6 +9079,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -8881,7 +9097,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8894,8 +9110,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8904,6 +9120,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -8912,8 +9129,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8928,7 +9145,7 @@
     <measure implicit="no" number="38">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -8955,8 +9172,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8965,12 +9182,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8982,8 +9200,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -8992,12 +9210,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9023,16 +9242,16 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9040,8 +9259,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9053,8 +9272,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9064,15 +9283,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9083,17 +9302,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9105,7 +9325,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9114,7 +9334,30 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9123,8 +9366,46 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9136,83 +9417,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9223,27 +9448,29 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 39 =========================-->
     <measure implicit="no" number="39">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9256,8 +9483,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9267,15 +9494,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9286,28 +9514,30 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9316,7 +9546,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9327,35 +9557,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9368,8 +9600,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9379,15 +9611,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9398,35 +9631,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9439,17 +9674,18 @@
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9460,35 +9696,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9504,8 +9742,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9515,15 +9753,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9534,17 +9773,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9556,26 +9796,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9586,16 +9827,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="84.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9609,7 +9851,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9618,8 +9860,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9627,11 +9869,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9640,7 +9883,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9649,11 +9892,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -9663,8 +9907,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9672,8 +9916,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9688,8 +9932,8 @@
     <measure implicit="no" number="41">
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9698,6 +9942,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -9714,8 +9959,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9724,13 +9969,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9755,7 +10001,7 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9768,8 +10014,8 @@
       </note>
       <note dynamics="92.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9781,7 +10027,7 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9816,8 +10062,8 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9837,8 +10083,8 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9847,6 +10093,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -9872,8 +10119,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9889,7 +10136,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -9903,8 +10150,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -9913,14 +10160,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 42 =========================-->
     <measure implicit="no" number="42">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9928,11 +10176,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -9941,8 +10190,8 @@
       </note>
       <note dynamics="94.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9951,7 +10200,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -9962,8 +10211,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9975,17 +10224,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -9997,8 +10247,8 @@
       </note>
       <note dynamics="98.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10007,6 +10257,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -10032,7 +10283,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10049,8 +10300,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10059,12 +10310,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10081,7 +10333,7 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10091,8 +10343,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10102,7 +10354,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10111,11 +10363,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10127,8 +10380,8 @@
     <measure implicit="no" number="43">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10137,6 +10390,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -10154,7 +10408,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10167,8 +10421,8 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10194,17 +10448,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10216,26 +10471,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10267,7 +10524,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10293,8 +10550,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10307,8 +10564,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10317,6 +10574,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -10333,8 +10591,8 @@
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10346,7 +10604,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10357,26 +10615,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10384,8 +10644,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10395,11 +10655,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 44 =========================-->
@@ -10411,7 +10672,108 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10422,8 +10784,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10431,72 +10793,37 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10509,8 +10836,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10520,87 +10847,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10609,19 +10877,20 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -10632,7 +10901,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10641,8 +10910,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10650,20 +10919,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10672,7 +10943,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10681,8 +10952,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10690,8 +10961,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10699,11 +10970,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -10715,7 +10987,7 @@
     <measure implicit="no" number="45">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10742,8 +11014,23 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10756,8 +11043,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10766,25 +11053,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10793,12 +11067,27 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -10812,22 +11101,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10839,8 +11114,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10849,6 +11124,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -10857,8 +11133,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -10870,7 +11146,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10879,17 +11155,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10901,7 +11178,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10912,8 +11189,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10921,16 +11198,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10940,8 +11217,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10953,8 +11230,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10964,16 +11241,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -10983,7 +11260,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -10992,8 +11269,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11001,11 +11278,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11014,7 +11292,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11040,8 +11318,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11054,8 +11332,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11068,8 +11346,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11078,6 +11356,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11091,7 +11370,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11108,8 +11387,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11122,8 +11401,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11132,12 +11411,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11152,8 +11432,8 @@
     <measure implicit="no" number="46">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11162,6 +11442,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -11179,7 +11460,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11192,8 +11473,8 @@
       </note>
       <note dynamics="103.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11202,11 +11483,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11224,8 +11506,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11234,6 +11516,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11242,7 +11525,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11251,8 +11534,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11260,11 +11543,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11273,8 +11557,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11282,16 +11566,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11316,7 +11600,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11331,8 +11615,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11341,6 +11625,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11357,8 +11642,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11366,8 +11651,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11375,7 +11660,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11383,7 +11668,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11409,8 +11694,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11423,8 +11708,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11433,6 +11718,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -11446,7 +11732,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11463,8 +11749,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11473,6 +11759,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 47 =========================-->
@@ -11485,15 +11772,15 @@
       </note>
       <note dynamics="92.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11519,8 +11806,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11529,6 +11816,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11542,7 +11830,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11559,8 +11847,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11569,10 +11857,20 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11581,20 +11879,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11603,17 +11893,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -11625,8 +11916,8 @@
       </note>
       <note dynamics="103.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11635,6 +11926,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -11651,7 +11943,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11666,8 +11958,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11676,6 +11968,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11692,7 +11985,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11701,18 +11994,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 48 =========================-->
     <measure implicit="no" number="48">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -11738,8 +12032,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -11748,6 +12042,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11786,7 +12081,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11803,8 +12098,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11813,6 +12108,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11839,7 +12135,7 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11852,7 +12148,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11861,11 +12157,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -11874,7 +12171,7 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11887,7 +12184,7 @@
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -11900,7 +12197,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11926,8 +12223,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11949,7 +12246,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -11966,8 +12263,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -11980,8 +12277,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12002,8 +12299,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12011,16 +12308,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12046,8 +12343,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12059,8 +12356,8 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12073,7 +12370,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12091,8 +12388,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12101,6 +12398,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12109,7 +12407,7 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12144,7 +12442,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12161,8 +12459,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12171,10 +12469,21 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12183,17 +12492,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12205,17 +12505,18 @@
       </note>
       <note dynamics="103.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12226,17 +12527,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12251,7 +12553,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12278,8 +12580,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12288,6 +12590,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12296,8 +12599,8 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12306,6 +12609,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -12334,8 +12638,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12343,7 +12647,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12356,7 +12660,7 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12369,8 +12673,8 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12404,7 +12708,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12421,8 +12725,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12435,8 +12739,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12445,14 +12749,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 51 =========================-->
     <measure implicit="no" number="51">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12462,8 +12767,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12471,7 +12776,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12479,8 +12784,8 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12489,6 +12794,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -12515,7 +12821,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12529,8 +12835,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12539,6 +12845,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12555,8 +12862,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12581,8 +12888,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12595,8 +12902,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12605,6 +12912,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12618,8 +12926,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12628,6 +12936,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -12636,8 +12945,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12650,8 +12959,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12663,7 +12972,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -12690,8 +12999,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12700,6 +13009,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12713,8 +13023,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -12723,13 +13033,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>16th</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -12742,8 +13053,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -12752,6 +13063,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
         <beam number="3">backward hook</beam>
@@ -12762,7 +13074,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -12775,11 +13087,12 @@
       </note>
       <note dynamics="106.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -12788,7 +13101,7 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12798,8 +13111,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12809,8 +13122,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12818,11 +13131,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 52 =========================-->
@@ -12834,26 +13148,27 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12864,17 +13179,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -12886,7 +13202,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12895,11 +13211,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -12908,7 +13225,7 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -12921,8 +13238,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12948,8 +13265,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12958,11 +13275,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12976,8 +13294,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -12990,8 +13308,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13003,7 +13321,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13021,8 +13339,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13031,12 +13349,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13053,7 +13372,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13079,8 +13398,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13089,6 +13408,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13102,7 +13422,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13119,8 +13439,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13129,14 +13449,15 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 53 =========================-->
     <measure implicit="no" number="53">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13161,8 +13482,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13171,12 +13492,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13198,8 +13520,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13215,8 +13537,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13229,7 +13551,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13242,8 +13564,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13251,8 +13573,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13264,8 +13586,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13273,8 +13595,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13286,8 +13608,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13297,16 +13619,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13316,8 +13638,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13329,7 +13651,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13355,8 +13677,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13411,8 +13733,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13428,8 +13750,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13463,8 +13785,8 @@
       </note>
       <note dynamics="136.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13489,8 +13811,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13502,7 +13824,7 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13517,7 +13839,7 @@
     <measure implicit="no" number="55">
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -13579,7 +13901,7 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -13618,7 +13940,7 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13628,18 +13950,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13652,7 +13975,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13661,8 +13984,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13670,11 +13993,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13683,7 +14007,7 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13696,7 +14020,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13705,8 +14029,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13718,8 +14042,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13729,7 +14053,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13737,8 +14061,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13748,7 +14072,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13764,8 +14088,8 @@
       </note>
       <note dynamics="88.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13774,7 +14098,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13785,7 +14109,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13793,8 +14117,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13821,8 +14145,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13831,6 +14155,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -13839,8 +14164,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13866,8 +14191,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13876,11 +14201,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13897,8 +14223,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -13915,27 +14241,28 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13945,15 +14272,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13964,8 +14291,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -13977,7 +14304,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -13986,17 +14322,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14008,7 +14335,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14017,8 +14344,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14028,8 +14355,8 @@
     <measure implicit="no" number="57">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14037,8 +14364,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14046,7 +14373,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14059,8 +14386,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14070,16 +14397,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14114,8 +14441,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14131,8 +14458,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14166,7 +14493,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14180,8 +14507,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14194,8 +14521,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14208,8 +14535,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14234,8 +14561,8 @@
       </note>
       <note dynamics="136.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14260,8 +14587,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14270,12 +14597,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14284,6 +14612,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -14294,8 +14623,8 @@
     <measure implicit="no" number="58">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14320,8 +14649,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14343,8 +14672,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14360,8 +14689,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14378,8 +14707,32 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14387,8 +14740,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14400,8 +14762,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14409,8 +14771,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14418,42 +14780,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14462,8 +14794,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14475,8 +14807,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14486,16 +14818,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14504,6 +14836,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -14558,8 +14891,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14575,8 +14908,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14611,7 +14944,7 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14624,7 +14957,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14633,8 +14966,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14642,11 +14975,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14668,8 +15002,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14677,8 +15011,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14690,7 +15024,7 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14703,7 +15037,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14712,8 +15046,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14721,11 +15055,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14747,8 +15082,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14773,8 +15108,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14796,8 +15131,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14809,8 +15144,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14827,8 +15162,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14840,7 +15175,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -14867,8 +15202,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14901,7 +15236,7 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -14914,8 +15249,8 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14927,8 +15262,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14936,8 +15271,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -14949,8 +15284,8 @@
       </note>
       <note dynamics="137.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -14980,11 +15315,12 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -14994,8 +15330,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15021,8 +15357,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15034,7 +15370,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15052,8 +15388,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15068,8 +15404,8 @@
     <measure implicit="no" number="63">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15095,7 +15431,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15108,8 +15444,8 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15135,7 +15471,33 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
+          <display-octave>4</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15144,34 +15506,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15183,7 +15519,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15194,16 +15530,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15213,7 +15550,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15222,8 +15559,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15235,8 +15572,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15261,7 +15598,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15284,8 +15621,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15301,8 +15638,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15319,8 +15656,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15328,8 +15665,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15341,8 +15678,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15350,8 +15687,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15366,8 +15703,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15377,16 +15714,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15396,16 +15733,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="136.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15417,8 +15755,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15428,7 +15766,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15436,8 +15774,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15447,8 +15785,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15460,7 +15798,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15469,8 +15807,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15482,8 +15820,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15491,8 +15829,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15504,8 +15842,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15530,8 +15868,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15553,7 +15891,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -15570,8 +15908,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15591,7 +15929,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15602,16 +15940,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15621,16 +15959,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="104.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15644,8 +15982,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15653,8 +15991,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15666,25 +16004,16 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15692,7 +16021,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15705,8 +16043,8 @@
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15715,7 +16053,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15726,8 +16064,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15735,8 +16073,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15748,8 +16086,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15757,11 +16095,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -15773,8 +16112,8 @@
     <measure implicit="no" number="66">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15782,8 +16121,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15795,24 +16134,25 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15820,8 +16160,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15833,8 +16173,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15842,16 +16182,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15877,8 +16218,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15887,27 +16228,20 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -15916,16 +16250,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15933,8 +16259,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -15946,8 +16290,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15972,8 +16316,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -15995,8 +16339,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16012,8 +16356,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16026,8 +16370,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16036,13 +16380,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 67 =========================-->
     <measure implicit="no" number="67">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16051,11 +16396,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -16064,20 +16410,22 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16086,18 +16434,19 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16107,25 +16456,26 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="128.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16136,15 +16486,70 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16157,8 +16562,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16166,64 +16571,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16235,8 +16588,8 @@
     <measure implicit="no" number="68">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16262,8 +16615,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16275,8 +16628,8 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16289,7 +16642,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16307,8 +16660,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16320,8 +16673,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16347,7 +16700,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16360,7 +16713,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16375,8 +16728,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16389,8 +16742,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16415,8 +16768,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16426,16 +16779,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16444,8 +16797,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16455,8 +16808,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16468,7 +16821,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16495,8 +16848,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16508,8 +16861,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16523,7 +16876,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16536,7 +16889,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16554,8 +16907,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16570,8 +16923,8 @@
     <measure implicit="no" number="69">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16580,6 +16933,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -16596,8 +16950,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16606,6 +16960,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -16619,8 +16974,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16629,13 +16984,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16662,8 +17018,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16675,8 +17031,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16690,7 +17046,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16704,7 +17060,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -16717,8 +17073,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16735,8 +17091,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16748,8 +17104,8 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16761,8 +17117,8 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16774,7 +17130,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16785,7 +17141,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16793,8 +17149,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16804,15 +17160,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16823,7 +17179,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -16831,11 +17187,12 @@
       </note>
       <note dynamics="131.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
@@ -16844,8 +17201,8 @@
     <measure implicit="no" number="70">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16854,6 +17211,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -16871,8 +17229,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16881,12 +17239,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16898,8 +17257,8 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -16925,17 +17284,18 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16947,8 +17307,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16958,16 +17318,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16981,8 +17341,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -16990,8 +17350,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17003,8 +17363,8 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17013,6 +17373,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="no" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -17034,7 +17395,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17060,8 +17421,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17070,6 +17431,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -17089,7 +17451,7 @@
     <measure implicit="no" number="71">
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17099,8 +17461,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17126,7 +17488,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17140,8 +17502,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17163,8 +17525,8 @@
       </note>
       <note dynamics="80.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17176,7 +17538,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17194,8 +17556,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17208,8 +17570,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17221,8 +17583,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17248,7 +17610,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17271,8 +17633,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -17287,8 +17649,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -17300,8 +17662,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -17320,8 +17682,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -17333,8 +17695,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17342,8 +17704,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17355,8 +17717,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17366,16 +17728,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17385,8 +17747,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17398,7 +17760,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17407,8 +17769,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17416,17 +17778,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17438,7 +17801,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17447,8 +17810,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17456,8 +17819,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17467,7 +17830,7 @@
     <measure implicit="no" number="72">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -17493,8 +17856,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -17507,8 +17870,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -17555,7 +17918,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17573,8 +17936,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17587,8 +17950,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17600,8 +17963,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17627,7 +17990,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17641,8 +18004,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17664,7 +18027,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17682,8 +18045,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17696,8 +18059,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17709,8 +18072,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17737,7 +18100,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -17751,8 +18114,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17764,8 +18127,8 @@
       </note>
       <note dynamics="135.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17777,8 +18140,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17788,16 +18151,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17807,15 +18170,24 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17824,17 +18196,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17846,8 +18209,8 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17856,7 +18219,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17867,8 +18230,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17876,8 +18239,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17887,8 +18250,8 @@
     <measure implicit="no" number="73">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17914,8 +18277,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17927,8 +18290,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17942,8 +18305,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -17973,7 +18336,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -17982,8 +18354,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -17991,17 +18363,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18013,7 +18376,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18022,8 +18385,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18031,16 +18394,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18048,8 +18411,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18061,8 +18424,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18072,16 +18435,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18091,7 +18454,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18100,8 +18463,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18109,16 +18472,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="75.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18130,7 +18494,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18139,20 +18512,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18164,7 +18529,7 @@
     <measure implicit="no" number="74">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18173,7 +18538,30 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18182,8 +18570,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18195,29 +18583,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18243,8 +18609,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18257,8 +18623,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18267,6 +18633,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18280,7 +18647,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18297,8 +18664,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18311,8 +18678,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18321,11 +18688,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18335,16 +18703,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18354,8 +18722,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18367,7 +18735,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18394,8 +18762,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18408,8 +18776,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18426,7 +18794,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18452,8 +18820,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18466,8 +18834,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18476,12 +18844,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18490,6 +18859,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18509,7 +18879,7 @@
     <measure implicit="no" number="75">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18536,8 +18906,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18550,8 +18920,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18560,12 +18930,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18574,11 +18945,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18592,8 +18964,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18606,7 +18978,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18632,8 +19004,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18641,8 +19013,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18650,17 +19022,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18672,8 +19045,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18681,8 +19054,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18694,8 +19067,8 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18704,7 +19077,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18715,16 +19088,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18734,7 +19107,25 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18743,29 +19134,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -18774,7 +19148,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18800,8 +19174,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18823,8 +19197,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18840,7 +19214,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18854,8 +19228,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18870,8 +19244,8 @@
     <measure implicit="no" number="76">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18897,8 +19271,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18907,10 +19281,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -18925,8 +19300,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -18951,7 +19326,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -18960,8 +19344,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -18969,34 +19353,27 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="87.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19008,8 +19385,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19019,7 +19396,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19028,8 +19405,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19037,16 +19414,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19056,8 +19434,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19069,8 +19447,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19080,16 +19458,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19099,7 +19477,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19108,8 +19486,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19117,11 +19495,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19130,8 +19509,8 @@
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19140,7 +19519,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19151,8 +19530,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19160,8 +19539,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19169,11 +19548,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -19182,7 +19562,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19191,8 +19571,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19207,8 +19587,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19217,6 +19597,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -19233,7 +19614,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19247,8 +19628,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19270,7 +19651,21 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19284,22 +19679,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19311,8 +19692,8 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19328,7 +19709,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19355,8 +19736,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19369,8 +19750,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19392,8 +19773,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -19408,7 +19789,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>1680</duration>
@@ -19422,8 +19803,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <type>16th</type>
@@ -19435,8 +19816,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -19455,7 +19836,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -19469,8 +19850,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -19487,8 +19868,8 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19497,8 +19878,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19508,8 +19889,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19517,7 +19898,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19530,7 +19911,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19539,8 +19920,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19548,8 +19929,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19564,8 +19945,8 @@
     <measure implicit="no" number="78">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19591,8 +19972,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19604,8 +19985,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19619,8 +20000,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19632,8 +20013,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19650,8 +20031,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19663,8 +20044,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19690,8 +20071,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19703,8 +20084,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19718,8 +20099,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19731,8 +20112,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19749,8 +20130,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19762,8 +20143,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19789,8 +20170,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19802,8 +20183,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19817,7 +20198,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19831,8 +20212,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19845,8 +20226,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19855,6 +20236,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -19871,8 +20253,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -19882,7 +20264,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -19891,25 +20282,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="114.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19944,7 +20326,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -19961,8 +20343,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19975,8 +20357,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19985,12 +20367,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -19999,13 +20382,24 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
     </measure>
     <!--========================= Measure 79 =========================-->
     <measure implicit="no" number="79">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20014,8 +20408,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20023,17 +20417,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20045,7 +20430,25 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20054,8 +20457,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20063,38 +20466,22 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20103,7 +20490,24 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20112,16 +20516,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20129,8 +20525,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20138,8 +20534,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20147,20 +20543,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20169,8 +20557,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20196,7 +20584,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20210,8 +20598,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20228,8 +20616,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20237,8 +20625,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20246,7 +20634,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20254,11 +20642,12 @@
       </note>
       <note dynamics="121.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20267,7 +20656,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20293,8 +20682,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20307,8 +20696,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20321,8 +20710,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20335,8 +20724,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20345,6 +20734,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -20358,7 +20748,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20375,8 +20765,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20391,8 +20781,18 @@
     <measure implicit="no" number="80">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20400,8 +20800,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20409,16 +20809,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20431,8 +20822,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20442,7 +20833,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20451,8 +20842,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20460,16 +20851,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="84.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20483,7 +20875,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20492,7 +20884,48 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20501,7 +20934,48 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <rest />
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20510,8 +20984,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20519,8 +20993,18 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20532,7 +21016,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20541,8 +21034,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20550,25 +21043,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20580,7 +21056,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20589,8 +21065,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20598,88 +21074,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <rest />
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20694,8 +21090,8 @@
     <measure implicit="no" number="81">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20704,6 +21100,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -20720,8 +21117,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20734,7 +21131,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20757,7 +21154,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20774,8 +21171,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20788,8 +21185,23 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20800,22 +21212,8 @@
         </time-modification>
       </note>
       <note>
-        <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20824,8 +21222,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20833,8 +21231,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20842,11 +21240,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -20856,8 +21255,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20883,8 +21282,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20896,7 +21295,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20911,8 +21310,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -20937,8 +21336,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20946,8 +21345,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -20955,7 +21354,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -20963,7 +21362,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -20989,8 +21388,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21003,8 +21402,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21013,6 +21412,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21026,8 +21426,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21043,7 +21443,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21057,8 +21457,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21083,7 +21483,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21092,8 +21492,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21105,7 +21505,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21114,8 +21514,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21123,8 +21523,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21136,7 +21536,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21162,8 +21562,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21176,8 +21576,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21199,8 +21599,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21209,6 +21609,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -21216,7 +21617,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21234,7 +21635,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21243,8 +21644,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21252,11 +21653,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21265,8 +21667,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21274,8 +21676,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21285,8 +21687,8 @@
     <measure implicit="no" number="83">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -21311,8 +21713,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -21359,8 +21761,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21377,8 +21779,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21390,8 +21792,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21417,8 +21819,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21430,21 +21832,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>3360</duration>
-        <type>eighth</type>
-        <time-modification>
-          <actual-notes>3</actual-notes>
-          <normal-notes>2</normal-notes>
-          <normal-type>eighth</normal-type>
-        </time-modification>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21458,8 +21846,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21468,6 +21856,21 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>3360</duration>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+        </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21484,7 +21887,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21511,8 +21914,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21525,8 +21928,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21543,7 +21946,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21554,26 +21957,27 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21582,8 +21986,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21595,7 +21999,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21621,8 +22025,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21631,6 +22035,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -21644,7 +22049,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21661,8 +22066,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21682,7 +22087,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21693,27 +22098,28 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21725,7 +22131,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21736,16 +22142,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21754,6 +22161,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -21771,7 +22179,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21794,8 +22202,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21808,8 +22216,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21818,10 +22226,11 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21838,8 +22247,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21848,6 +22257,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -21865,7 +22275,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21878,8 +22288,8 @@
       </note>
       <note dynamics="93.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21888,6 +22298,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -21895,7 +22306,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21904,11 +22315,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21917,7 +22329,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -21926,8 +22338,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -21935,11 +22347,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -21951,7 +22364,7 @@
     <measure implicit="no" number="85">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -21978,8 +22391,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -21991,8 +22404,8 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22001,11 +22414,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22023,8 +22437,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22033,6 +22447,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -22058,7 +22473,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22072,8 +22487,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22086,8 +22501,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22096,12 +22511,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22110,6 +22526,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22126,8 +22543,8 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22186,7 +22603,7 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22210,7 +22627,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22236,8 +22653,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22259,7 +22676,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22280,7 +22697,7 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22293,7 +22710,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22302,11 +22719,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22315,7 +22733,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22324,8 +22742,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22333,11 +22751,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22346,8 +22765,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22373,8 +22792,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22391,8 +22810,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22417,7 +22836,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22446,7 +22865,7 @@
     <measure implicit="no" number="87">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22455,8 +22874,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22468,7 +22887,7 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22478,18 +22897,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22502,7 +22922,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22511,11 +22931,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22524,7 +22945,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22533,11 +22954,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22546,7 +22968,7 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22559,17 +22981,18 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22605,8 +23028,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22615,6 +23038,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet number="1" type="stop" />
         </notations>
@@ -22622,7 +23046,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22638,8 +23062,8 @@
     <measure implicit="no" number="88">
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -22648,7 +23072,7 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22684,8 +23108,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22694,11 +23118,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22711,8 +23136,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22728,7 +23153,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22742,8 +23167,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22752,6 +23177,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22777,8 +23203,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22787,11 +23213,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22804,8 +23231,8 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22821,7 +23248,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22848,8 +23275,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -22874,7 +23301,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22883,11 +23310,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -22896,7 +23324,7 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -22911,7 +23339,7 @@
     <measure implicit="no" number="89">
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -22973,7 +23401,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -22990,8 +23418,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23000,6 +23428,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23038,8 +23467,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23047,8 +23476,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23060,8 +23489,8 @@
       </note>
       <note dynamics="102.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23074,7 +23503,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23101,8 +23530,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23111,19 +23540,21 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23131,7 +23562,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23147,8 +23578,8 @@
     <measure implicit="no" number="90">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23174,8 +23605,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23184,11 +23615,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23197,13 +23629,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23228,11 +23661,12 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23241,7 +23675,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23250,20 +23693,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23272,8 +23707,8 @@
       </note>
       <note dynamics="106.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23282,6 +23717,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -23307,7 +23743,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23321,8 +23757,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23347,8 +23783,8 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23388,8 +23824,8 @@
     <measure implicit="no" number="91">
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23398,6 +23834,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -23414,8 +23851,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23429,7 +23866,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23443,8 +23880,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23453,6 +23890,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23469,8 +23907,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23478,11 +23916,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23491,8 +23930,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23517,7 +23956,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23540,8 +23979,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23557,8 +23996,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23567,6 +24006,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23575,8 +24015,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23584,8 +24024,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23597,8 +24037,8 @@
       </note>
       <note dynamics="100.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23610,8 +24050,8 @@
       </note>
       <note dynamics="76.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23645,7 +24085,7 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23669,7 +24109,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23678,8 +24118,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23692,7 +24132,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23718,8 +24158,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23741,7 +24181,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -23758,8 +24198,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23768,6 +24208,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23776,7 +24217,7 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23786,18 +24227,19 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23810,7 +24252,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23819,11 +24261,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23832,7 +24275,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -23841,8 +24284,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -23850,18 +24293,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 93 =========================-->
     <measure implicit="no" number="93">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>840</duration>
@@ -23887,8 +24331,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -23901,8 +24345,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <type>32nd</type>
@@ -23911,6 +24355,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>32nd</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -23949,8 +24394,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23967,8 +24412,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -23980,8 +24425,8 @@
       </note>
       <note dynamics="111.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24007,7 +24452,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24016,11 +24461,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24029,7 +24475,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24038,8 +24484,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24047,11 +24493,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24060,8 +24507,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24070,6 +24517,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -24087,7 +24535,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24101,8 +24549,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24111,11 +24559,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24124,13 +24573,14 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">continue</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24143,7 +24593,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24156,8 +24606,8 @@
       </note>
       <note dynamics="97.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24166,6 +24616,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
         <notations>
           <tuplet number="1" type="stop" />
@@ -24173,7 +24624,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24200,8 +24651,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24210,11 +24661,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24223,12 +24675,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">end</beam>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24254,8 +24707,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24263,18 +24716,19 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
     </measure>
     <!--========================= Measure 94 =========================-->
     <measure implicit="no" number="94">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24283,11 +24737,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24296,17 +24751,18 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24317,11 +24773,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24330,7 +24787,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24339,8 +24796,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24348,11 +24805,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -24361,7 +24819,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24370,15 +24828,25 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24387,17 +24855,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24409,17 +24868,18 @@
       </note>
       <note dynamics="96.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">forward hook</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24447,8 +24907,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24457,6 +24917,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24465,7 +24926,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24491,8 +24952,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24505,8 +24966,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24515,6 +24976,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24531,7 +24993,7 @@
       </note>
       <note dynamics="116.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24547,17 +25009,18 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24568,11 +25031,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24581,7 +25045,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24590,8 +25054,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24599,8 +25063,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24608,11 +25072,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24621,7 +25086,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24630,11 +25095,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -24644,8 +25110,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24671,8 +25137,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24689,7 +25155,7 @@
       </note>
       <note dynamics="112.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24730,7 +25196,7 @@
     <measure implicit="no" number="96">
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24743,7 +25209,7 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24756,7 +25222,7 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24769,7 +25235,7 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24782,7 +25248,7 @@
       </note>
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24795,7 +25261,7 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24808,8 +25274,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24817,7 +25283,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24830,8 +25296,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24839,7 +25305,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24860,7 +25326,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24886,8 +25352,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -24909,7 +25375,7 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24925,8 +25391,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -24934,16 +25400,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -24956,7 +25423,7 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -24987,7 +25454,7 @@
       </note>
       <note dynamics="107.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25025,7 +25492,7 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25035,8 +25502,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25046,7 +25513,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25062,7 +25529,7 @@
     <measure implicit="no" number="98">
       <note dynamics="113.33">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25075,7 +25542,7 @@
       </note>
       <note dynamics="108.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25088,7 +25555,7 @@
       </note>
       <note dynamics="110.00">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25101,8 +25568,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25110,8 +25577,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25119,7 +25586,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25132,8 +25599,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25141,7 +25608,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25154,7 +25621,7 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25167,7 +25634,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25176,8 +25643,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25192,7 +25659,16 @@
     <measure implicit="no" number="99">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25201,20 +25677,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25224,7 +25692,7 @@
       </note>
       <note dynamics="122.22">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25237,8 +25705,8 @@
       </note>
       <note dynamics="130.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25250,7 +25718,7 @@
       </note>
       <note dynamics="118.89">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25260,7 +25728,7 @@
       </note>
       <note dynamics="115.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25270,7 +25738,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25281,15 +25749,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25321,7 +25789,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25347,8 +25815,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25373,8 +25841,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25382,8 +25850,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25398,7 +25866,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25407,8 +25875,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25420,7 +25888,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25429,8 +25897,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25438,11 +25906,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25451,7 +25920,7 @@
       </note>
       <note dynamics="117.78">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25464,7 +25933,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25473,8 +25951,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25482,20 +25960,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25504,8 +25974,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25513,11 +25983,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25526,7 +25997,16 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>2520</duration>
+        <type>16th</type>
+      </note>
+      <note>
+        <chord />
+        <unpitched>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25535,8 +26015,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25544,20 +26024,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
-      </note>
-      <note>
-        <chord />
-        <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
-        </unpitched>
-        <duration>2520</duration>
-        <type>16th</type>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25566,7 +26038,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25575,8 +26047,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25586,8 +26058,8 @@
     <measure implicit="no" number="101">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25612,7 +26084,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25626,8 +26098,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25640,8 +26112,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25650,6 +26122,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <rest />
@@ -25663,8 +26136,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25680,8 +26153,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25690,11 +26163,12 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="98.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25703,6 +26177,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <beam number="1">begin</beam>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
@@ -25719,7 +26194,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25734,8 +26209,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25748,8 +26223,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25758,12 +26233,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25788,7 +26264,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25797,8 +26273,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25806,11 +26282,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -25819,8 +26296,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25828,7 +26305,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25841,8 +26318,8 @@
       </note>
       <note dynamics="127.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25854,7 +26331,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25863,8 +26340,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25879,7 +26356,7 @@
     <measure implicit="no" number="102">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25888,8 +26365,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25901,7 +26378,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -25910,8 +26387,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25919,8 +26396,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -25932,8 +26409,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25942,6 +26419,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -25967,7 +26445,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -25984,8 +26462,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -25998,8 +26476,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26008,12 +26486,13 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">circle-x</notehead>
       </note>
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26022,6 +26501,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -26030,11 +26510,12 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -26043,8 +26524,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26054,7 +26535,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26063,7 +26544,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26072,16 +26553,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26091,8 +26572,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26100,11 +26581,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -26121,8 +26603,8 @@
       </note>
       <note dynamics="120.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26131,6 +26613,7 @@
           <normal-notes>2</normal-notes>
           <normal-type>eighth</normal-type>
         </time-modification>
+        <notehead parentheses="no">x</notehead>
         <notations>
           <tuplet bracket="yes" number="1" placement="above" type="start">
             <tuplet-actual>
@@ -26156,8 +26639,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26177,7 +26660,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26188,8 +26671,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26197,15 +26680,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26216,8 +26699,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26229,7 +26712,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26238,8 +26721,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26256,7 +26739,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26267,8 +26750,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26276,16 +26759,17 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note dynamics="76.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <tie type="start" />
@@ -26301,8 +26785,8 @@
     <measure implicit="no" number="104">
       <note dynamics="76.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -26363,7 +26847,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26380,7 +26864,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26394,8 +26878,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26407,8 +26891,8 @@
       </note>
       <note dynamics="136.67">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26433,8 +26917,8 @@
       </note>
       <note dynamics="101.11">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26446,8 +26930,8 @@
       </note>
       <note dynamics="138.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26459,7 +26943,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26485,7 +26969,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26499,8 +26983,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26512,8 +26996,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26526,8 +27010,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26539,8 +27023,8 @@
       </note>
       <note dynamics="123.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26578,15 +27062,15 @@
       </note>
       <note dynamics="140.00">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26595,7 +27079,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26611,8 +27095,8 @@
     <measure implicit="no" number="105">
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26622,16 +27106,16 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note dynamics="137.78">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26666,7 +27150,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26683,8 +27167,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26696,7 +27180,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26705,7 +27189,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26718,8 +27202,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26727,7 +27211,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26740,7 +27224,7 @@
       </note>
       <note dynamics="124.44">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26750,8 +27234,8 @@
       </note>
       <note dynamics="134.44">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26760,8 +27244,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26771,15 +27255,15 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26790,7 +27274,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26798,8 +27282,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26824,7 +27308,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26839,7 +27323,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26865,8 +27349,8 @@
       </note>
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26876,7 +27360,7 @@
     <measure implicit="no" number="106">
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26903,8 +27387,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -26916,7 +27400,7 @@
       </note>
       <note dynamics="125.56">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -26943,7 +27427,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26952,7 +27436,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -26961,8 +27445,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -26974,8 +27458,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27000,8 +27484,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27023,8 +27507,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27037,8 +27521,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27050,8 +27534,8 @@
       </note>
       <note dynamics="138.89">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27067,8 +27551,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27094,7 +27578,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -27117,7 +27601,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -27135,7 +27619,7 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -27148,8 +27632,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27184,8 +27668,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>1680</duration>
         <tie type="start" />
@@ -27203,8 +27687,8 @@
       </note>
       <note dynamics="132.22">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>840</duration>
         <tie type="stop" />
@@ -27227,8 +27711,8 @@
     <measure implicit="no" number="107">
       <note dynamics="133.33">
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27253,8 +27737,8 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27268,8 +27752,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27281,7 +27765,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>3360</duration>
@@ -27299,8 +27783,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>3360</duration>
         <type>eighth</type>
@@ -27312,7 +27796,7 @@
       </note>
       <note dynamics="126.67">
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27325,7 +27809,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27334,8 +27818,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -27347,7 +27831,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27356,8 +27840,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -27365,8 +27849,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -27379,7 +27863,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27388,8 +27872,8 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>D</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
@@ -27397,11 +27881,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>A</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />
@@ -27420,7 +27905,7 @@
       </note>
       <note>
         <unpitched>
-          <display-step>B</display-step>
+          <display-step>F</display-step>
           <display-octave>4</display-octave>
         </unpitched>
         <duration>2520</duration>
@@ -27429,11 +27914,12 @@
       <note>
         <chord />
         <unpitched>
-          <display-step>B</display-step>
-          <display-octave>4</display-octave>
+          <display-step>G</display-step>
+          <display-octave>5</display-octave>
         </unpitched>
         <duration>2520</duration>
         <type>16th</type>
+        <notehead parentheses="no">x</notehead>
       </note>
       <note>
         <rest />


### PR DESCRIPTION
Sample XMLs under `public/transcription-samples/*/adtof*` regenerated with the fixed drum converters from groovesheet/groovesheet-be#15. The old files had every unpitched note at music21's B4 display default, so the /video2fordrums sheet rendered the whole kit on one line.

Verified rendered output on /video2fordrums (percussion clef, kick/snare/toms positioned, x noteheads for hi-hat/cymbals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)