### PR TITLE
feat(drums): enable drum transcription on the home page

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -45,9 +45,9 @@ const isSupportedFileType = (selectedFile) => {
 
 const API_BASE_URL = config.apiBaseUrl;
 
-// TODO(launch): only piano is production-ready today. The other instruments are
+// TODO(launch): piano and drums are production-ready today. The other instruments are
 // temporarily hidden from the picker — add them back here once their pipelines ship.
-const VISIBLE_INSTRUMENTS = ['piano'];
+const VISIBLE_INSTRUMENTS = ['piano', 'drums'];
 
 // NOTE: Download key maps (stemKeyMap, midiKeyMap) and download handlers are shared across
 // Hero.js, MidiConverter.js, StemSplitter.js, and TranscriptionHistory.js.
@@ -425,7 +425,7 @@ function Hero({ onLoginRequired }) {
       // Workflow name selection
       let workflowName = 'bs_roformer_separate';
       if (selectedInstrument === 'drums') {
-        workflowName = 'separate_to_drumscore_full';
+        workflowName = 'separate_to_drumscore_v2_full';
       } else if (selectedInstrument === 'jazz_bass') {
         workflowName = 'separate_to_jazz_bass_score_full';
       } else if (selectedInstrument === 'bass') {
@@ -635,7 +635,7 @@ function Hero({ onLoginRequired }) {
       other: 'bs_roformer_other_stem',
     };
     const midiKeyMap = {
-      drums: 'adtof_drums_midi',
+      drums: 'adtof_plus_drums_quantized_midi',
       jazz_bass: 'bassunet_jazz_bass_midi',
       bass: 'fcpe_bass_midi',
       piano: 'transkun_v2_piano_midi',
@@ -801,7 +801,7 @@ function Hero({ onLoginRequired }) {
   // Download MIDI using backend descriptive keys
   const handleDownloadMidi = () => {
     const midiKeyMap = {
-      drums: 'adtof_drums_midi',
+      drums: 'adtof_plus_drums_quantized_midi',
       jazz_bass: 'bassunet_jazz_bass_midi',
       bass: 'fcpe_bass_midi',
       piano: 'transkun_v2_piano_midi',

--- a/src/components/MidiConverter.js
+++ b/src/components/MidiConverter.js
@@ -238,7 +238,7 @@ function MidiConverter({ onLoginClick }) {
   // or /preview prefix — the upload helper picks based on auth state).
   const workflowNameFor = (instrument) => {
     switch (instrument) {
-      case 'drums': return 'separate_to_drumscore';
+      case 'drums': return 'separate_to_drumscore_v2';
       case 'jazz_bass': return 'separate_to_jazz_bass_score';
       case 'bass': return 'separate_to_bass_score';
       case 'piano': return 'separate_to_piano_score_full';
@@ -423,7 +423,7 @@ function MidiConverter({ onLoginClick }) {
       other: 'bs_roformer_other_stem',
     };
     const midiKeyMap = {
-      drums: 'adtof_drums_midi',
+      drums: 'adtof_plus_drums_quantized_midi',
       jazz_bass: 'bassunet_jazz_bass_midi',
       bass: 'fcpe_bass_midi',
       piano: 'transkun_v2_piano_midi',
@@ -451,7 +451,7 @@ function MidiConverter({ onLoginClick }) {
   // Same download logic as home page Hero
   const downloadInstrumentFile = async (id) => {
     const midiKeyMap = {
-      drums: 'adtof_drums_midi',
+      drums: 'adtof_plus_drums_quantized_midi',
       jazz_bass: 'bassunet_jazz_bass_midi',
       bass: 'fcpe_bass_midi',
       piano: 'transkun_v2_piano_midi',
@@ -571,7 +571,7 @@ function MidiConverter({ onLoginClick }) {
   // Download MIDI (only for transcription instruments)
   const handleDownloadMidi = () => {
     const midiKeyMap = {
-      drums: 'adtof_drums_midi',
+      drums: 'adtof_plus_drums_quantized_midi',
       jazz_bass: 'bassunet_jazz_bass_midi',
       bass: 'fcpe_bass_midi',
       piano: 'transkun_v2_piano_midi',

--- a/src/components/PreviewPanel/PreviewBottomBar.js
+++ b/src/components/PreviewPanel/PreviewBottomBar.js
@@ -12,12 +12,23 @@ import {
   CaretDown,
 } from '@phosphor-icons/react';
 
-const SOURCES = [
-  { id: 'transcription', label: 'Transcription', Icon: MusicNotes },
-  { id: 'midi', label: 'MIDI', Icon: Equalizer },
-  { id: 'piano_stem', label: 'Piano Stem', Icon: GitMerge },
-  { id: 'original', label: 'Original', Icon: FileIcon },
-];
+// Stem-source label per instrument; anything unlisted keeps the historical
+// piano wording so existing surfaces render byte-identically.
+const STEM_SOURCE_LABEL_BY_INSTRUMENT = {
+  drums: 'Drums Stem',
+  bass: 'Bass Stem',
+  jazz_bass: 'Bass Stem',
+};
+
+function buildSources(instrument) {
+  const stemLabel = STEM_SOURCE_LABEL_BY_INSTRUMENT[instrument] || 'Piano Stem';
+  return [
+    { id: 'transcription', label: 'Transcription', Icon: MusicNotes },
+    { id: 'midi', label: 'MIDI', Icon: Equalizer },
+    { id: 'piano_stem', label: stemLabel, Icon: GitMerge },
+    { id: 'original', label: 'Original', Icon: FileIcon },
+  ];
+}
 
 const SPEED_OPTIONS = [0.5, 0.75, 1, 1.25, 1.5, 2];
 
@@ -42,7 +53,9 @@ export default function PreviewBottomBar({
   onChangeSpeed,
   activeSource: activeSourceProp,
   onChangeSource,
+  instrument,
 }) {
+  const sources = buildSources(instrument);
   const [localPlaying, setLocalPlaying] = useState(isPlaying);
   const [sourcesExpanded, setSourcesExpanded] = useState(false);
   const [localSource, setLocalSource] = useState('transcription');
@@ -61,7 +74,7 @@ export default function PreviewBottomBar({
     if (onChangeSpeed) onChangeSpeed(s);
     setSpeedOpen(false);
   };
-  const activeLabel = SOURCES.find((s) => s.id === activeSource)?.label || 'Audio Source';
+  const activeLabel = sources.find((s) => s.id === activeSource)?.label || 'Audio Source';
   const node = (
     <div className="preview-bottom-bar">
       <div className="preview-bottom-bar-left">
@@ -124,7 +137,7 @@ export default function PreviewBottomBar({
       <div className="preview-bottom-bar-right">
         {sourcesExpanded ? (
           <div className="preview-bottom-bar-sources" role="radiogroup" aria-label="Audio source">
-            {SOURCES.map(({ id, label, Icon }) => {
+            {sources.map(({ id, label, Icon }) => {
               const isActive = id === activeSource;
               return (
                 <button

--- a/src/components/PreviewPanel/PreviewPanel.js
+++ b/src/components/PreviewPanel/PreviewPanel.js
@@ -1,14 +1,19 @@
 import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../../auth';
-import { fetchMidiArrayBuffer, fetchMusicXmlText } from '../../utils/api';
+import { downloadWorkflowFile, fetchMidiArrayBuffer, fetchMusicXmlText } from '../../utils/api';
 import config from '../../config';
 import PreviewTabs from './PreviewTabs';
 import PreviewControls from './PreviewControls';
 import PreviewBottomBar from './PreviewBottomBar';
-import { MIDI_KEY_BY_INSTRUMENT, MUSICXML_KEY_BY_INSTRUMENT, truncateMidiToSeconds } from './previewUtils';
+import {
+  MIDI_KEY_BY_INSTRUMENT,
+  MUSICXML_KEY_BY_INSTRUMENT,
+  SYNC_MAP_KEY_BY_INSTRUMENT,
+  truncateMidiToSeconds,
+} from './previewUtils';
 import { createTransport } from '../../player/transport';
 import { useTransport } from '../../player/transport-react';
-import { createSheetSecMapper } from '../../player/syncMap';
+import { createSheetSecMapper, parseSyncMap } from '../../player/syncMap';
 import StatusMessage from '../ui/StatusMessage';
 import SkeletonPanel from '../ui/SkeletonPanel';
 import './PreviewPanel.css';
@@ -94,6 +99,7 @@ export default function PreviewPanel({
   const isTranscriptionInstrument = isDemoMode || TRANSCRIPTION_INSTRUMENTS.includes(selectedInstrument);
   const midiKey = MIDI_KEY_BY_INSTRUMENT[selectedInstrument];
   const musicXmlKey = MUSICXML_KEY_BY_INSTRUMENT[selectedInstrument];
+  const syncMapKey = SYNC_MAP_KEY_BY_INSTRUMENT[selectedInstrument];
 
   const rebuildMapper = useCallback(() => {
     mapperRef.current = createSheetSecMapper({
@@ -106,6 +112,37 @@ export default function PreviewPanel({
     syncMapRef.current = preloadedSyncMap || null;
     rebuildMapper();
   }, [preloadedSyncMap, rebuildMapper]);
+
+  // Fetch the per-instrument sync map when the chain emits one (currently
+  // drums only — SYNC_MAP_KEY_BY_INSTRUMENT). Best-effort: a missing or
+  // invalid map leaves the identity mapping in place, so the OSMD cursor
+  // simply follows the score's own timing. Instruments without a sync map
+  // key skip this entirely.
+  useEffect(() => {
+    if (isDemoMode || !workflowId || !syncMapKey) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const prefetched = prefetchedFiles?.[syncMapKey];
+        let text;
+        if (prefetched?.blob) {
+          text = await prefetched.blob.text();
+        } else {
+          const result = await downloadWorkflowFile(config.apiBaseUrl, workflowId, syncMapKey, getToken);
+          text = result ? await result.blob.text() : null;
+        }
+        if (cancelled || !text) return;
+        const map = parseSyncMap(text);
+        if (cancelled) return;
+        syncMapRef.current = map;
+        rebuildMapper();
+      } catch (err) {
+        // Degrade gracefully — no sync map, cursor uses OSMD default timing.
+        console.warn('Preview sync map unavailable:', err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [workflowId, syncMapKey, prefetchedFiles, getToken, isDemoMode, rebuildMapper]);
 
   useEffect(() => {
     if (isDemoMode) {
@@ -506,6 +543,7 @@ export default function PreviewPanel({
         onSkipBack={handleSkipBack}
         speed={speed}
         onChangeSpeed={handleChangeSpeed}
+        instrument={selectedInstrument}
       />
     </div>
   );

--- a/src/components/PreviewPanel/previewUtils.js
+++ b/src/components/PreviewPanel/previewUtils.js
@@ -40,15 +40,23 @@ export function truncateMidiToSeconds(arrayBuffer, seconds = PREVIEW_SECONDS) {
 }
 
 export const MIDI_KEY_BY_INSTRUMENT = {
-  drums: 'adtof_drums_midi',
+  drums: 'adtof_plus_drums_quantized_midi',
   jazz_bass: 'bassunet_jazz_bass_midi',
   bass: 'fcpe_bass_midi',
   piano: 'transkun_v2_piano_midi',
 };
 
 export const MUSICXML_KEY_BY_INSTRUMENT = {
-  drums: 'adtof_drums_musicxml',
+  drums: 'adtof_plus_drums_musicxml',
   jazz_bass: 'bassunet_jazz_bass_musicxml',
   bass: 'fcpe_bass_musicxml',
   piano: 'transkun_v2_piano_musicxml',
+};
+
+// Optional per-instrument sync map output ({ version, pairs: [[qn, sec], ...] },
+// see src/player/syncMap.js). Only chains that emit one are listed; when the
+// key is absent (or the download 404s) the playback cursor falls back to the
+// score's own timing (identity mapping).
+export const SYNC_MAP_KEY_BY_INSTRUMENT = {
+  drums: 'adtof_plus_drums_sync_map',
 };

--- a/src/components/TranscriptionResult/DrumKitView.css
+++ b/src/components/TranscriptionResult/DrumKitView.css
@@ -1,0 +1,15 @@
+/* DrumKitView — "Drum Kit" tab inside the transcription result viewer.
+   The stage matches PianoRollView's 460px canvas height and the sheet tab's
+   translucent well so the three tabs read as one surface in both themes. */
+
+.tr-drumkit {
+  position: relative;
+}
+
+.tr-drumkit-stage {
+  height: 460px;
+  background: rgba(0, 0, 0, 0.18);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: opacity 0.2s ease;
+}

--- a/src/components/TranscriptionResult/DrumKitView.js
+++ b/src/components/TranscriptionResult/DrumKitView.js
@@ -1,0 +1,101 @@
+// DrumKitView — the "Drum Kit" tab of the transcription result viewer.
+//
+// Renders the existing top-down kit visualiser (src/components/video/
+// VideoDrumKit.js) fed by hits parsed from the ADToF+ quantized drum MIDI
+// (`adtof_plus_drums_quantized_midi`, GM channel-10 pitches, times aligned to
+// the real audio). Parsing mirrors PianoRollView in src/components/song/
+// SongViewers.js (@tonejs/midi), but reduced to note-on hits [{time, midi}].
+//
+// Clock: VideoDrumKit polls `timeRef.current` inside its own rAF loop, so we
+// hand it a getter that reads the SHARED transport's position each frame —
+// the same clock the stem-audio engine drives — and the flashes line up with
+// the audio without any extra animation loop here.
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Midi } from '@tonejs/midi';
+import VideoDrumKit from '../video/VideoDrumKit';
+import SkeletonPanel from '../ui/SkeletonPanel';
+import StatusMessage from '../ui/StatusMessage';
+import './DrumKitView.css';
+
+// GM percussion lives on MIDI channel 10 (0-indexed 9).
+const PERCUSSION_CHANNEL = 9;
+
+/**
+ * Parse a MIDI ArrayBuffer into kit hits [{time, midi}].
+ * Note-on events only (velocity > 0), across all tracks; tracks flagged as
+ * channel-10 percussion are preferred, with an all-tracks fallback for files
+ * that don't carry channel metadata.
+ */
+function parseDrumHits(midiBuffer) {
+  const midi = new Midi(midiBuffer);
+  const withNotes = midi.tracks.filter((t) => t.notes && t.notes.length);
+  const percussion = withNotes.filter((t) => t.channel === PERCUSSION_CHANNEL);
+  const tracks = percussion.length ? percussion : withNotes;
+  const hits = tracks
+    .flatMap((t) => t.notes)
+    .filter((n) => n.velocity > 0)
+    .map((n) => ({ time: n.time, midi: n.midi }));
+  hits.sort((a, b) => a.time - b.time);
+  return hits;
+}
+
+export default function DrumKitView({ midiBuffer, transport, loading, error }) {
+  const transportRef = useRef(transport);
+  useEffect(() => {
+    transportRef.current = transport;
+  }, [transport]);
+
+  // Live clock for VideoDrumKit: a ref-shaped object whose `current` getter
+  // reads the shared transport position, so every rAF frame inside the kit
+  // sees the same time the audio engines are at.
+  const timeRef = useMemo(
+    () => ({
+      get current() {
+        const t = transportRef.current;
+        return t ? t.getPosition() : 0;
+      },
+    }),
+    []
+  );
+
+  const parsed = useMemo(() => {
+    if (!midiBuffer) return { hits: null, parseError: null };
+    try {
+      return { hits: parseDrumHits(midiBuffer), parseError: null };
+    } catch (e) {
+      return { hits: null, parseError: 'Could not parse the drum MIDI file.' };
+    }
+  }, [midiBuffer]);
+
+  const showError = (error || parsed.parseError) && !loading;
+  const empty = !loading && !showError && parsed.hits && parsed.hits.length === 0;
+  const ready = !loading && !showError && parsed.hits && parsed.hits.length > 0;
+
+  return (
+    <div className="tr-drumkit">
+      {loading && (
+        <div style={{ padding: 24 }}>
+          <SkeletonPanel count={1} height={200} />
+        </div>
+      )}
+      {showError && (
+        <div style={{ padding: 24 }}>
+          <StatusMessage variant="error">{error || parsed.parseError}</StatusMessage>
+        </div>
+      )}
+      {empty && (
+        <div style={{ maxWidth: 560, margin: '48px auto 0', padding: '0 24px' }}>
+          <StatusMessage variant="info" title="No drum hits detected">
+            We couldn&apos;t find any drum hits in this section of the audio. Try a
+            recording where the drums are clearly audible.
+          </StatusMessage>
+        </div>
+      )}
+      {ready && (
+        <div className="tr-drumkit-stage">
+          <VideoDrumKit notes={parsed.hits} timeRef={timeRef} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TranscriptionResult/DrumKitView.js
+++ b/src/components/TranscriptionResult/DrumKitView.js
@@ -10,6 +10,14 @@
 // hand it a getter that reads the SHARED transport's position each frame —
 // the same clock the stem-audio engine drives — and the flashes line up with
 // the audio without any extra animation loop here.
+//
+// Origin shift: the quantized MIDI is on SCORE time (t=0 is the score's first
+// downbeat), while the transport plays the full-length stem on REAL time — on
+// songs whose drums enter late the origins differ by that intro (~15 s on
+// some songs). The drums sync map's first anchor is the score origin in real
+// seconds, so the clock getter subtracts it; both timelines run at real
+// tempo, making the constant shift exact. No sync map → 0, which matches the
+// v1 ADToF MIDI (real-time aligned already).
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Midi } from '@tonejs/midi';
 import VideoDrumKit from '../video/VideoDrumKit';
@@ -39,20 +47,29 @@ function parseDrumHits(midiBuffer) {
   return hits;
 }
 
-export default function DrumKitView({ midiBuffer, transport, loading, error }) {
+export default function DrumKitView({ midiBuffer, transport, syncPairsRef, loading, error }) {
   const transportRef = useRef(transport);
   useEffect(() => {
     transportRef.current = transport;
   }, [transport]);
 
   // Live clock for VideoDrumKit: a ref-shaped object whose `current` getter
-  // reads the shared transport position, so every rAF frame inside the kit
-  // sees the same time the audio engines are at.
+  // reads the shared transport position (shifted onto score time via the sync
+  // map's first anchor — see header comment), so every rAF frame inside the
+  // kit sees the same time the audio engines are at. Reading the offset
+  // lazily from the ref means a late-arriving sync map needs no re-render.
+  const syncRef = useRef(syncPairsRef);
+  useEffect(() => {
+    syncRef.current = syncPairsRef;
+  }, [syncPairsRef]);
   const timeRef = useMemo(
     () => ({
       get current() {
         const t = transportRef.current;
-        return t ? t.getPosition() : 0;
+        if (!t) return 0;
+        const pairs = syncRef.current?.current;
+        const origin = pairs && pairs.length ? pairs[0][1] : 0;
+        return t.getPosition() - origin;
       },
     }),
     []

--- a/src/components/TranscriptionResult/TranscriptionResultView.js
+++ b/src/components/TranscriptionResult/TranscriptionResultView.js
@@ -649,6 +649,7 @@ export default function TranscriptionResultView({
             <DrumKitView
               midiBuffer={midiBuffer}
               transport={transport}
+              syncPairsRef={syncPairsRef}
               loading={midiLoading}
               error={midiError}
             />

--- a/src/components/TranscriptionResult/TranscriptionResultView.js
+++ b/src/components/TranscriptionResult/TranscriptionResultView.js
@@ -4,6 +4,7 @@
 // workflow/preview outputs instead of library assets.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CheckCircle, DownloadSimple, File, X } from '@phosphor-icons/react';
+import { Drum } from 'lucide-react';
 import { useAuth } from '../../auth';
 import { useTheme } from '../../context/ThemeContext';
 import config from '../../config';
@@ -15,6 +16,7 @@ import {
   truncateMusicXmlToMeasures,
 } from '../PreviewPanel/previewUtils';
 import { SheetMusicView, PianoRollView, StemsView } from '../song/SongViewers';
+import DrumKitView from './DrumKitView';
 import PlaybackBar from '../song/PlaybackBar';
 import { Icon } from '../song/icons';
 import StatusMessage from '../ui/StatusMessage';
@@ -22,11 +24,19 @@ import { createTransport } from '../../player/transport';
 import { useTransport } from '../../player/transport-react';
 import { createStemEngine } from '../../player/stemEngine';
 import { createMidiEngine } from '../../player/midiEngine';
-import { createSheetSecMapper } from '../../player/syncMap';
+import { createSheetSecMapper, parseSyncMap } from '../../player/syncMap';
 import '../song/Song.css';
 import './TranscriptionResult.css';
 
 const nowMs = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+// Drums viewer outputs — the beat-tracked ADToF+ chain. The engraved score
+// carries per-bar hidden tempo marks that OSMD ignores, so cursor sync runs
+// through the sync map below; the quantized MIDI is aligned to the real audio.
+// TODO: consolidate into api.js key maps
+const DRUMS_MUSICXML_KEY = 'adtof_plus_drums_musicxml';
+const DRUMS_MIDI_KEY = 'adtof_plus_drums_quantized_midi';
+const DRUMS_SYNC_MAP_KEY = 'adtof_plus_drums_sync_map';
 
 // Hero instrument value → BS-Roformer stem download key.
 const STEM_KEY_BY_INSTRUMENT = {
@@ -52,7 +62,10 @@ const STEM_DISPLAY = {
   other: { name: 'other', label: 'Other', color: '#C9A0FF', sub: 'texture · residual' },
 };
 
-function ViewerToolbar({ view, onView, available }) {
+// Lucide instrument icon sized to match the inline tab icons.
+const DrumKitTabIcon = (p) => <Drum size={14} strokeWidth={2} aria-hidden="true" {...p} />;
+
+function ViewerToolbar({ view, onView, available, drums }) {
   const tab = (key, IconCmp, label, kbd) => {
     const enabled = Boolean(available[key]);
     return (
@@ -73,7 +86,7 @@ function ViewerToolbar({ view, onView, available }) {
     <div className="gs-viewer-toolbar">
       <div className="gs-seg" role="tablist">
         {tab('sheet', Icon.Sheet, 'Sheet music', '1')}
-        {tab('midi', Icon.Midi, 'Piano roll', '2')}
+        {drums ? tab('midi', DrumKitTabIcon, 'Drum Kit', '2') : tab('midi', Icon.Midi, 'Piano roll', '2')}
         {tab('stems', Icon.Stems, 'Stem', '3')}
       </div>
     </div>
@@ -99,8 +112,12 @@ export default function TranscriptionResultView({
   const containerRef = useRef(null);
 
   const isPreview = Boolean(workflowId && workflowId.startsWith('PRV'));
-  const midiKey = MIDI_KEY_BY_INSTRUMENT[selectedInstrument];
-  const musicXmlKey = MUSICXML_KEY_BY_INSTRUMENT[selectedInstrument];
+  // Drums route to the beat-tracked ADToF+ outputs; every drums-specific
+  // branch below gates on this flag so the default (piano/bass/…) path is
+  // untouched.
+  const isDrums = selectedInstrument === 'drums';
+  const midiKey = isDrums ? DRUMS_MIDI_KEY : MIDI_KEY_BY_INSTRUMENT[selectedInstrument];
+  const musicXmlKey = isDrums ? DRUMS_MUSICXML_KEY : MUSICXML_KEY_BY_INSTRUMENT[selectedInstrument];
   const stemKey = STEM_KEY_BY_INSTRUMENT[selectedInstrument];
   const stemMeta = STEM_DISPLAY[selectedInstrument] || STEM_DISPLAY.other;
 
@@ -301,13 +318,52 @@ export default function TranscriptionResultView({
   const osmdSyncRef = useRef({ time: 0, playing: false, duration: 0, ready: false });
   const osmdBaseRef = useRef(0);
   const mapperRef = useRef(createSheetSecMapper({}));
+  const syncPairsRef = useRef(null);
   const sheetDurRef = useRef(0);
   const pendingOsmdSyncRef = useRef(false);
   const osmdExpectRef = useRef(null); // { sheetSec, until } | null
 
   const rebuildMapper = useCallback(() => {
-    mapperRef.current = createSheetSecMapper({ sheetDurationSec: sheetDurRef.current });
+    // pairs stay null unless a drums sync map loaded, in which case the mapper
+    // composes midi-sec ↔ score-qn with the sheet's own clock (same wiring as
+    // SongDetail). Null pairs → identity, the pre-drums behavior.
+    mapperRef.current = createSheetSecMapper({
+      pairs: syncPairsRef.current,
+      sheetDurationSec: sheetDurRef.current,
+    });
   }, []);
+
+  // Drums sheet↔audio sync map. The ADToF+ score is beat-tracked with per-bar
+  // hidden tempo marks that OSMD ignores, so without this map the playback
+  // cursor drifts ahead of the audio. Missing or invalid file → keep the
+  // identity mapping (graceful degradation, no crash). Previews are skipped:
+  // the sheet is truncated client-side, which would break the full-song map's
+  // qn → sheet-seconds scale.
+  useEffect(() => {
+    if (!workflowId || !isDrums || isPreview) return undefined;
+    let cancelled = false;
+    syncPairsRef.current = null; // drop any previous workflow's map while fetching
+    rebuildMapper();
+    (async () => {
+      try {
+        const prefetched = prefetchedFiles?.[DRUMS_SYNC_MAP_KEY];
+        const result = prefetched?.blob
+          ? prefetched
+          : await downloadWorkflowFile(config.apiBaseUrl, workflowId, DRUMS_SYNC_MAP_KEY, getToken);
+        if (cancelled || !result?.blob) return;
+        const pairs = parseSyncMap(await result.blob.text()).pairs;
+        if (cancelled) return;
+        syncPairsRef.current = pairs;
+        rebuildMapper();
+      } catch (e) {
+        if (!cancelled) {
+          syncPairsRef.current = null; // absent/bad sync map → identity mapping
+          rebuildMapper();
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [workflowId, isDrums, isPreview, prefetchedFiles, getToken, rebuildMapper]);
 
   // OSMD's playFromMs awaits pause() internally; serialize seek/play commands.
   const osmdCmdQueueRef = useRef(Promise.resolve());
@@ -574,7 +630,7 @@ export default function TranscriptionResultView({
           totalBeats={0}
           disabledControls={{ tempo: true, transpose: true, metronome: true, loop: true }}
         />
-        <ViewerToolbar view={view} onView={setView} available={available} />
+        <ViewerToolbar view={view} onView={setView} available={available} drums={isDrums} />
       </div>
 
       {/* Viewer */}
@@ -589,12 +645,21 @@ export default function TranscriptionResultView({
           />
         )}
         {view === 'midi' && (
-          <PianoRollView
-            midiBuffer={midiBuffer}
-            transport={transport}
-            loading={midiLoading}
-            error={midiError}
-          />
+          isDrums ? (
+            <DrumKitView
+              midiBuffer={midiBuffer}
+              transport={transport}
+              loading={midiLoading}
+              error={midiError}
+            />
+          ) : (
+            <PianoRollView
+              midiBuffer={midiBuffer}
+              transport={transport}
+              loading={midiLoading}
+              error={midiError}
+            />
+          )
         )}
         {view === 'stems' && (
           <StemsView

--- a/src/components/visualization/MidiEditorView.js
+++ b/src/components/visualization/MidiEditorView.js
@@ -8,7 +8,7 @@ const API_BASE_URL = config.apiBaseUrl;
 
 // MIDI file key mapping per instrument
 const MIDI_KEY_MAP = {
-  drums: 'adtof_drums_midi',
+  drums: 'adtof_plus_drums_quantized_midi',
   piano: 'transkun_v2_piano_midi',
   bass: 'fcpe_bass_midi',
   jazz_bass: 'bassunet_jazz_bass_midi',

--- a/src/components/visualization/PianoRollView.js
+++ b/src/components/visualization/PianoRollView.js
@@ -8,7 +8,7 @@ import SkeletonPanel from '../ui/SkeletonPanel';
 const API_BASE_URL = config.apiBaseUrl;
 
 const MIDI_KEY_MAP = {
-  drums: 'adtof_drums_midi',
+  drums: 'adtof_plus_drums_quantized_midi',
   piano: 'transkun_v2_piano_midi',
   bass: 'fcpe_bass_midi',
   jazz_bass: 'bassunet_jazz_bass_midi',

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -322,24 +322,40 @@ const STEM_KEYS = {
 };
 
 const MIDI_KEYS = {
-  drums: 'adtof_drums_midi',
+  // Prefer the ADToF+ quantized MIDI: it matches the displayed beat-tracked score.
+  drums: ['adtof_plus_drums_quantized_midi', 'adtof_plus_drums_midi', 'adtof_drums_midi'],
   piano: 'transkun_v2_piano_midi',
   bass: 'fcpe_bass_midi',
   jazz_bass: 'bassunet_jazz_bass_midi',
 };
 
 const TRANSCRIPTION_KEYS = {
-  drums: 'adtof_drums_musicxml',
+  drums: ['adtof_plus_drums_musicxml', 'adtof_drums_musicxml'],
   piano: 'transkun_v2_piano_musicxml',
   bass: 'fcpe_bass_musicxml',
   jazz_bass: 'bassunet_jazz_bass_musicxml',
 };
 
 const SCORE_KEYS = {
-  drums: 'midi2score_drums_musicxml',
+  drums: ['midi2score_drums_v2_musicxml', 'midi2score_drums_musicxml'],
   piano: 'midi2score_piano_musicxml',
   bass: 'midi2score_bass_musicxml',
   jazz_bass: 'midi2score_jazz_bass_musicxml',
+};
+
+const asKeyList = (value) => (Array.isArray(value) ? value : [value]).filter(Boolean);
+
+const selectOutputKey = (keyMap, instrument, outputs, workflowName = '') => {
+  const fallback = keyMap[instrument] || keyMap.drums;
+  const keys = asKeyList(fallback);
+  if (outputs && typeof outputs === 'object') {
+    return keys.find((key) => outputs[key]) || keys[0];
+  }
+  if (instrument === 'drums' && !workflowName.includes('_v2')) {
+    // Legacy v1 drum workflows (no outputs metadata) predate the ADToF+ keys.
+    return keys.find((key) => !key.includes('_plus') && !key.includes('_v2')) || keys[0];
+  }
+  return keys[0];
 };
 
 /**
@@ -357,11 +373,12 @@ export function resolveAvailableOutputs(workflow) {
   // The status payload nests file keys under outputs.files (outputs also
   // carries a metadata block); older payloads used a flat files map.
   const outputs = workflow.outputs?.files || workflow.files || null;
+  const workflowName = workflow.workflow_name || '';
 
   const stemKey = STEM_KEYS[instrument] || STEM_KEYS.drums;
-  const midiKey = MIDI_KEYS[instrument] || MIDI_KEYS.drums;
-  const transcriptionKey = TRANSCRIPTION_KEYS[instrument] || TRANSCRIPTION_KEYS.drums;
-  const scoreKey = SCORE_KEYS[instrument] || SCORE_KEYS.drums;
+  const midiKey = selectOutputKey(MIDI_KEYS, instrument, outputs, workflowName);
+  const transcriptionKey = selectOutputKey(TRANSCRIPTION_KEYS, instrument, outputs, workflowName);
+  const scoreKey = selectOutputKey(SCORE_KEYS, instrument, outputs, workflowName);
 
   if (outputs && typeof outputs === 'object') {
     // Backend explicitly lists available output keys
@@ -382,18 +399,24 @@ export function resolveAvailableOutputs(workflow) {
   }
 
   // Fallback: infer from workflow_name when no explicit outputs metadata
-  const workflowName = workflow.workflow_name || '';
-  const isSeparationOnly = workflowName.includes('separate') && !workflowName.includes('full');
+  const stemOnlyWorkflows = new Set([
+    'bs_roformer_separate',
+    'demucs_separate',
+    'separate_to_guitar_stem',
+    'compress_stems',
+  ]);
+  const isStemOnlyWorkflow = stemOnlyWorkflows.has(workflowName);
+  const isTranscriptionInstrument = ['drums', 'jazz_bass', 'bass', 'piano'].includes(instrument);
   const isFullWorkflow = workflowName.includes('_full');
 
   return {
     instrument: { available: true, fileKey: stemKey },
-    transcription: isSeparationOnly
-      ? { available: false }
-      : { available: true, fileKey: transcriptionKey },
-    midi: isSeparationOnly
-      ? { available: false }
-      : { available: true, fileKey: midiKey },
+    transcription: isTranscriptionInstrument && !isStemOnlyWorkflow
+      ? { available: true, fileKey: transcriptionKey }
+      : { available: false },
+    midi: isTranscriptionInstrument && !isStemOnlyWorkflow
+      ? { available: true, fileKey: midiKey }
+      : { available: false },
     score: isFullWorkflow
       ? { available: true, fileKey: scoreKey }
       : { available: false },


### PR DESCRIPTION
## What

Drums becomes a first-class transcription option next to Piano.

- **Hero picker:** drums unhidden, launching the ADToF+ v2 chain (`separate_to_drumscore_v2_full`; MidiConverter uses `separate_to_drumscore_v2`).
- **Result viewer:** renders the beat-tracked percussion staff; the playback cursor is warped by the new `adtof_plus_drums_sync_map` through the existing `createSheetSecMapper` plumbing, with identity fallback when the key is absent. The piano-roll tab becomes a **Drum Kit** tab — `VideoDrumKit` (from `/video2fordrums`) fed by hits parsed from the quantized MIDI (`@tonejs/midi`, same parser as the piano roll) on the shared playback transport, so flashes track whichever engine owns playback.
- **Preview:** anonymous 10s previews get the same percussion sheet + synced cursor (`PreviewPanel` self-fetches the sync map; stem label is instrument-aware).
- **Key maps:** all drum download/prefetch maps prefer ADToF+ keys — quantized MIDI matches the displayed score — with v1 `adtof_drums_*` fallbacks so old history items keep working. Includes two stale hardcoded keys in `MidiEditorView`/`PianoRollView` that would have 404'd on v2 jobs.

Piano behavior is byte-identical — every drums branch is gated on the instrument value.

## Depends on

groovesheet-be#17 (sync-map emitter). Safe to merge FE first — the cursor falls back to identity mapping — but tempo-varying songs will show cursor drift until the BE side deploys, so recommended order is BE → FE.

## Verification

- `CI=true npm run build` passes (warnings-as-errors mode), +980 B gzipped.
- eslint clean on all touched files.

## QA suggestions

Test one song with a late drum entry and one with mid-song tempo changes (the historically bug-prone cases), on both the authenticated flow and the anonymous preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)